### PR TITLE
better running logs

### DIFF
--- a/Bullseye/Internal/Logger.cs
+++ b/Bullseye/Internal/Logger.cs
@@ -37,11 +37,11 @@ namespace Bullseye.Internal
         public Task Running(List<string> targets) =>
             this.console.Out.WriteLineAsync(Message(MessageType.Start, $"Running {targets.Quote()}...", null));
 
-        public Task Failed(List<string> targets, Exception ex, double elapsedMilliseconds) =>
-            this.console.Out.WriteLineAsync(Message(MessageType.Failure, $"Failed to run {targets.Quote()}!", elapsedMilliseconds));
+        public Task Failed(Exception ex, double elapsedMilliseconds) =>
+            this.console.Out.WriteLineAsync(Message(MessageType.Failure, $"Failed!", elapsedMilliseconds));
 
-        public Task Succeeded(List<string> targets, double elapsedMilliseconds) =>
-            this.console.Out.WriteLineAsync(Message(MessageType.Success, $"{targets.Quote()} succeeded.", elapsedMilliseconds));
+        public Task Succeeded(double elapsedMilliseconds) =>
+            this.console.Out.WriteLineAsync(Message(MessageType.Success, $"Succeeded.", elapsedMilliseconds));
 
         public Task Starting(string target) =>
             this.console.Out.WriteLineAsync(Message(MessageType.Start, "Starting...", target, null));

--- a/Bullseye/Internal/TargetCollection.cs
+++ b/Bullseye/Internal/TargetCollection.cs
@@ -33,11 +33,11 @@ namespace Bullseye.Internal
             }
             catch (Exception ex)
             {
-                await log.Failed(names, ex, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
+                await log.Failed(ex, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
                 throw;
             }
 
-            await log.Succeeded(names, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
+            await log.Succeeded(stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
         }
 
         private async Task RunAsync(string name, bool skipDependencies, bool dryRun, ISet<string> targetsRan, Logger log)


### PR DESCRIPTION
## Before

### Success

![image](https://user-images.githubusercontent.com/677704/42124544-b34e219e-7c64-11e8-98a7-3a2e77e03699.png)

This is OK, but seems repetitive.

### Failure

![image](https://user-images.githubusercontent.com/677704/42124548-c1ecf18a-7c64-11e8-98cb-70f4ee3838ea.png)

The last line is confusing, since "build" actually succeeded.

## After

### Success

![image](https://user-images.githubusercontent.com/677704/42124555-e2556a4c-7c64-11e8-8864-e6b5388e267a.png)

The repetition is gone.

### Failure

![image](https://user-images.githubusercontent.com/677704/42124558-f99c4496-7c64-11e8-9012-880ccd277285.png)

The confusion is gone.