### PR TITLE
Fail when circular deps are detected

### DIFF
--- a/BullseyeTests/Infra/Helper.cs
+++ b/BullseyeTests/Infra/Helper.cs
@@ -19,6 +19,9 @@ namespace BullseyeTests.Infra
         public static Target CreateTarget(string name, string[] dependencies, Action action) =>
             new TargetWithoutInput(name, dependencies.ToList(), action.ToAsync());
 
+        public static Target CreateTarget(string name, string[] dependencies) =>
+            new TargetWithoutInput(name, dependencies.ToList(), null);
+
         public static Target CreateTarget<TInput>(string name, IEnumerable<TInput> forEach, Action<TInput> action) =>
             new Target<TInput>(name, new string[0], forEach, action.ToAsync());
 
@@ -28,6 +31,7 @@ namespace BullseyeTests.Infra
                 action();
                 return Task.FromResult(0);
             };
+
         private static Func<TInput, Task> ToAsync<TInput>(this Action<TInput> action) =>
             input =>
             {


### PR DESCRIPTION
Previously, a circular dependency was simply ignored. That is problematic. For example:

`x` depends on `y`, `y` depends on `z`, and `z` depends on `x`.

- If I run `x`, then the execution order will be `z`, `y`, `x`.
- If I run `y`, then the execution order will be `x`, `z`, `y`.
- If I run `z`, then the execution order will be `y`, `x`, `z`.

This is a simple example, but in more complicated dependency graphs, it could be very difficult to work out the conditions under which a specific target in the dependency chain will be run, i.e. which targets will or will not have executed before it, since it may not be obvious where the circles in the dependency graph exist.

With this change, an exception is thrown before any targets are run, with a message of the form:

> Circular dependency detected: x -> y -> z -> x

If the `--skip-dependencies` option is used, the circular dependency check is not performed.