### PR TITLE
Use dependency graph to inform build order, even when skipping dependencies

### DIFF
--- a/Bullseye/Internal/TargetCollection.cs
+++ b/Bullseye/Internal/TargetCollection.cs
@@ -21,22 +21,23 @@ namespace Bullseye.Internal
             {
                 if (!skipDependencies)
                 {
-                    this.ValidateDependencies();
+                    this.ValidateDependenciesAreAllDefined();
                 }
 
+                this.ValidateTargetGraphIsCycleFree();
                 this.Validate(names);
 
                 var targetsRan = new ConcurrentDictionary<string, Task>();
                 if (parallel)
                 {
-                    var tasks = names.Select(name => this.RunAsync(name, skipDependencies, dryRun, parallel, targetsRan, log));
+                    var tasks = names.Select(name => this.RunAsync(name, names, skipDependencies, dryRun, parallel, targetsRan, log));
                     await Task.WhenAll(tasks).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (var name in names)
                     {
-                        await this.RunAsync(name, skipDependencies, dryRun, parallel, targetsRan, log).ConfigureAwait(false);
+                        await this.RunAsync(name, names, skipDependencies, dryRun, parallel, targetsRan, log).ConfigureAwait(false);
                     }
                 }
             }
@@ -49,30 +50,35 @@ namespace Bullseye.Internal
             await log.Succeeded(names, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
         }
 
-        private async Task RunAsync(string name, bool skipDependencies, bool dryRun, bool parallel, ConcurrentDictionary<string, Task> targetsRan, Logger log)
+        private async Task RunAsync(string name, List<string> explicitTargets, bool skipDependencies, bool dryRun, bool parallel, ConcurrentDictionary<string, Task> targetsRan, Logger log)
         {
+            if (!this.Contains(name))
+            {
+                return;
+            }
+
             var target = this[name];
 
-            if (!skipDependencies)
+            if (parallel)
             {
-                if (parallel)
+                var tasks = target.Dependencies.Select(dependency => this.RunAsync(dependency, explicitTargets, skipDependencies, dryRun, parallel, targetsRan, log));
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            else
+            {
+                foreach (var dependency in target.Dependencies)
                 {
-                    var tasks = target.Dependencies.Select(dependency => this.RunAsync(dependency, skipDependencies, dryRun, parallel, targetsRan, log));
-                    await Task.WhenAll(tasks).ConfigureAwait(false);
-                }
-                else
-                {
-                    foreach (var dependency in target.Dependencies)
-                    {
-                        await this.RunAsync(dependency, skipDependencies, dryRun, parallel, targetsRan, log).ConfigureAwait(false);
-                    }
+                    await this.RunAsync(dependency, explicitTargets, skipDependencies, dryRun, parallel, targetsRan, log).ConfigureAwait(false);
                 }
             }
 
-            await targetsRan.GetOrAdd(name, _ => target.RunAsync(dryRun, parallel, log)).ConfigureAwait(false);
+            if (!skipDependencies || explicitTargets.Contains(name))
+            {
+                await targetsRan.GetOrAdd(name, _ => target.RunAsync(dryRun, parallel, log)).ConfigureAwait(false);
+            }
         }
 
-        private void ValidateDependencies()
+        private void ValidateDependenciesAreAllDefined()
         {
             var unknownDependencies = new SortedDictionary<string, SortedSet<string>>();
 
@@ -98,7 +104,10 @@ namespace Bullseye.Internal
 
                 throw new Exception(message);
             }
+        }
 
+        private void ValidateTargetGraphIsCycleFree()
+        {
             var dependencyChain = new Stack<string>();
             foreach (var target in this)
             {
@@ -116,7 +125,7 @@ namespace Bullseye.Internal
 
             dependencyChain.Push(target.Name);
 
-            foreach (var dependency in target.Dependencies)
+            foreach (var dependency in target.Dependencies.Where(this.Contains))
             {
                 WalkDependencies(this[dependency], dependencyChain);
             }


### PR DESCRIPTION
Connects to #101.
Closes #112.