### PR TITLE
don't log exception message when already logged by an input invocation

### DIFF
--- a/Bullseye/Internal/ActionTarget`1.cs
+++ b/Bullseye/Internal/ActionTarget`1.cs
@@ -56,9 +56,10 @@ namespace Bullseye.Internal
                     }
                 }
             }
-            catch (Exception ex)
+
+            catch (Exception)
             {
-                await log.Failed(this.Name, ex, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
+                await log.Failed(this.Name, stopWatch.Elapsed.TotalMilliseconds).ConfigureAwait(false);
                 throw;
             }
 

--- a/Bullseye/Internal/Logger.cs
+++ b/Bullseye/Internal/Logger.cs
@@ -81,6 +81,9 @@ namespace Bullseye.Internal
         public Task Failed(string target, Exception ex, double elapsedMilliseconds) =>
             this.console.Out.WriteLineAsync(Message(p.Failed, $"Failed! {ex.Message}", target, elapsedMilliseconds));
 
+        public Task Failed(string target, double elapsedMilliseconds) =>
+            this.console.Out.WriteLineAsync(Message(p.Failed, $"Failed!", target, elapsedMilliseconds));
+
         public Task Succeeded(string target, double? elapsedMilliseconds) =>
             this.console.Out.WriteLineAsync(Message(p.Succeeded, "Succeeded.", target, elapsedMilliseconds));
 


### PR DESCRIPTION
Not such an issue when running in serial, but when running in parallel, and multiple inputs fail, only one of the exception messages is shown.

## Before

<img src="https://user-images.githubusercontent.com/677704/49686685-75345f00-faf8-11e8-9f1f-e12c3ef2677f.png" width="300px" />

## After

<img src="https://user-images.githubusercontent.com/677704/49686692-8aa98900-faf8-11e8-9d8e-b2a5fdfbd405.png" width="295px" />


