### PR TITLE
don't catch general exception types

### DIFF
--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -39,11 +39,6 @@ namespace Bullseye.Internal
             {
                 Environment.Exit(ex.InnerException.HResult == 0 ? 1 : ex.InnerException.HResult);
             }
-            catch (Exception ex)
-            {
-                await log.Error(ex.ToString()).ConfigureAwait(false);
-                Environment.Exit(ex.HResult == 0 ? 1 : ex.HResult);
-            }
 
             Environment.Exit(0);
         }


### PR DESCRIPTION
Relates to #172.

This would indicate a bug in Bullseye, so it's better to allow the exception to be handled or unhandled normally.