### PR TITLE
return exit code 1 for target failure

### DIFF
--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -35,9 +35,9 @@ namespace Bullseye.Internal
                 await log.Error(ex.Message).ConfigureAwait(false);
                 Environment.Exit(2);
             }
-            catch (TargetFailedException ex)
+            catch (TargetFailedException)
             {
-                Environment.Exit(ex.InnerException.HResult == 0 ? 1 : ex.InnerException.HResult);
+                Environment.Exit(1);
             }
 
             Environment.Exit(0);


### PR DESCRIPTION
Relates to #172.

When running in parallel there may be multiple target failures, and this would only surface the `HResult` of one of them. Not to mention that the `HResult` probably isn't much use as an exit code anyway.