### PR TITLE
remove redundant IsTestProject property

### DIFF
--- a/Bullseye/Bullseye.csproj
+++ b/Bullseye/Bullseye.csproj
@@ -4,7 +4,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Description>For describing and running targets and their dependencies.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <PackageIconUrl>https://raw.githubusercontent.com/adamralph/bullseye/master/assets/bullseye.png</PackageIconUrl>

--- a/BullseyeSmokeTester/BullseyeSmokeTester.csproj
+++ b/BullseyeSmokeTester/BullseyeSmokeTester.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/BullseyeTests/BullseyeTests.csproj
+++ b/BullseyeTests/BullseyeTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
This was added to remove this annoying message in anticipation of https://github.com/Microsoft/vstest/issues/1866:

> Skipping running test for project {project file}. To run tests with dotnet test add "true" property to project file.

But this is not the right solution. The log level for that message should be reduced, as per https://github.com/Microsoft/vstest/pull/1867/files#r244541222

For test projects, there is no need to set this property to `true`, since that is done by `Microsoft.NET.Test.Sdk`.