### PR TITLE
better colour for target names in log

### DIFF
--- a/Bullseye/Internal/ConsoleExtensions.cs
+++ b/Bullseye/Internal/ConsoleExtensions.cs
@@ -75,6 +75,10 @@ namespace Bullseye.Internal
                 {
                     options.Host = Host.GitHubActions;
                 }
+                else if (Environment.GetEnvironmentVariable("GITLAB_CI")?.ToUpperInvariant() == "TRUE")
+                {
+                    options.Host = Host.GitLabCI;
+                }
                 else if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TRAVIS_OS_NAME")))
                 {
                     options.Host = Host.Travis;
@@ -82,6 +86,10 @@ namespace Bullseye.Internal
                 else if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME")))
                 {
                     options.Host = Host.TeamCity;
+                }
+                else if (Environment.GetEnvironmentVariable("TERM_PROGRAM")?.ToUpperInvariant() == "VSCODE")
+                {
+                    options.Host = Host.VisualStudioCode;
                 }
             }
 

--- a/Bullseye/Internal/Host.cs
+++ b/Bullseye/Internal/Host.cs
@@ -7,7 +7,9 @@ namespace Bullseye.Internal
         Appveyor,
         AzurePipelines,
         GitHubActions,
+        GitLabCI,
         Travis,
         TeamCity,
+        VisualStudioCode,
     }
 }

--- a/Bullseye/Internal/Logger.cs
+++ b/Bullseye/Internal/Logger.cs
@@ -248,16 +248,16 @@ namespace Bullseye.Internal
             $"{GetPrefix(target, input)}{color}{text}{p.Default}{GetSuffix(true, elapsedMilliseconds)}{p.Default}";
 
         private string GetPrefix() =>
-            $"{p.Label}{prefix}{p.Symbol}: {p.Default}";
+            $"{p.Prefix}{prefix}{p.Symbol}: {p.Default}";
 
         private string GetPrefix(Stack<string> targets) =>
-            $"{p.Label}{prefix}{p.Symbol}: {p.Target}{string.Join($"{p.Symbol}/{p.Target}", targets.Reverse())}{p.Symbol}: {p.Default}";
+            $"{p.Prefix}{prefix}{p.Symbol}: {p.Target}{string.Join($"{p.Symbol}/{p.Target}", targets.Reverse())}{p.Symbol}: {p.Default}";
 
         private string GetPrefix(string target) =>
-            $"{p.Label}{prefix}{p.Symbol}: {p.Target}{target}{p.Symbol}: {p.Default}";
+            $"{p.Prefix}{prefix}{p.Symbol}: {p.Target}{target}{p.Symbol}: {p.Default}";
 
         private string GetPrefix<TInput>(string target, TInput input) =>
-            $"{p.Label}{prefix}{p.Symbol}: {p.Target}{target}{p.Symbol}({p.Input}{input}{p.Symbol}): {p.Default}";
+            $"{p.Prefix}{prefix}{p.Symbol}: {p.Target}{target}{p.Symbol}({p.Input}{input}{p.Symbol}): {p.Default}";
 
         private string GetSuffix(bool specific, double? elapsedMilliseconds) =>
             (!specific && this.dryRun ? $"{p.Option} (dry run){p.Default}" : "") +

--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -117,6 +117,7 @@ $@"{p.Label}Usage: {p.CommandLine}<command-line> {p.Option}[<options>] {p.Target
  {p.Option}    --appveyor             {p.Text}Force Appveyor mode (normally auto-detected)
  {p.Option}    --azure-pipelines      {p.Text}Force Azure Pipelines mode (normally auto-detected)
  {p.Option}    --github-actions       {p.Text}Force GitHub Actions mode (normally auto-detected)
+ {p.Option}    --gitlab-ci            {p.Text}Force GitLab CI mode (normally auto-detected)
  {p.Option}    --teamcity             {p.Text}Force TeamCity mode (normally auto-detected)
  {p.Option}    --travis               {p.Text}Force Travis CI mode (normally auto-detected)
  {p.Option}-h, --help, -?             {p.Text}Show this help, then exit (case insensitive)

--- a/Bullseye/Internal/Palette.cs
+++ b/Bullseye/Internal/Palette.cs
@@ -49,12 +49,13 @@ namespace Bullseye.Internal
             this.Default = @default;
             this.Failed = brightRed;
             this.Input = brightCyan;
-            this.Label = cyan;
+            this.Label = white;
             this.Option = brightMagenta;
+            this.Prefix = brightBlack;
             this.Starting = white;
             this.Succeeded = green;
             this.Symbol = white;
-            this.Target = brightWhite;
+            this.Target = cyan;
             this.Tree = green;
             this.Text = white;
             this.Timing = magenta;
@@ -69,9 +70,9 @@ namespace Bullseye.Internal
             if (host == Host.Appveyor &&
                 (operatingSystem == OperatingSystem.Windows || operatingSystem == OperatingSystem.Linux))
             {
-                this.Label = brightBlue;
                 this.Starting = brightBlack;
                 this.Symbol = brightBlack;
+                this.Target = blue;
                 this.Text = brightBlack;
 
                 if (operatingSystem == OperatingSystem.Windows)
@@ -93,20 +94,19 @@ namespace Bullseye.Internal
                 this.CommandLine = yellow;
                 this.Failed = red;
                 this.Input = cyan;
-                this.Label = blue;
                 this.Option = magenta;
                 this.Starting = brightBlack;
                 this.Symbol = brightBlack;
-                this.Target = white;
+                this.Target = blue;
                 this.Text = brightBlack;
                 this.Warning = yellow;
             }
 
             if (host == Host.TeamCity)
             {
-                this.Label = brightBlue;
                 this.Starting = brightBlack;
                 this.Symbol = brightBlack;
+                this.Target = brightBlue;
                 this.Text = brightBlack;
             }
 
@@ -114,7 +114,17 @@ namespace Bullseye.Internal
             {
                 this.CommandLine = yellow;
                 this.Failed = red;
-                this.Label = blue;
+                this.Target = blue;
+            }
+
+            if (host == Host.GitLabCI)
+            {
+                this.Target = blue;
+            }
+
+            if (host == Host.VisualStudioCode)
+            {
+                this.Target = blue;
             }
         }
 
@@ -129,6 +139,8 @@ namespace Bullseye.Internal
         public string Label { get; }
 
         public string Option { get; }
+
+        public string Prefix { get; }
 
         public string Starting { get; }
 

--- a/Bullseye/Internal/StringExtensions.cs
+++ b/Bullseye/Internal/StringExtensions.cs
@@ -69,6 +69,9 @@ namespace Bullseye.Internal
                     case "--github-actions":
                         options.Host = Host.GitHubActions;
                         break;
+                    case "--gitlab-ci":
+                        options.Host = Host.GitLabCI;
+                        break;
                     case "--travis":
                         options.Host = Host.Travis;
                         break;


### PR DESCRIPTION
closes #316
closes #317
closes #318

- [x] Appveyor
- [x] Azure Pipelines
- [x] GitHub Actions
- [x] GitLab CI
- [x] TeamCity
- [x] Travis CI
- [x] Linux term (Mint 19.2)
- [x] Windows cmd
- [x] Windows Cmder
- [x] Windows PS
- [x] Windows Git Bash
- [x] WSL
- [x] VS Code
- [x] Rider
