### PR TITLE
add option for no extended chars

### DIFF
--- a/Bullseye/Internal/ConsoleExtensions.cs
+++ b/Bullseye/Internal/ConsoleExtensions.cs
@@ -93,7 +93,7 @@ namespace Bullseye.Internal
                 }
             }
 
-            var palette = new Palette(options.NoColor, options.Host, operatingSystem);
+            var palette = new Palette(options.NoColor, options.NoExtendedChars, options.Host, operatingSystem);
             var output = new Output(Console.Out, palette);
             var log = new Logger(Console.Error, logPrefix, options.SkipDependencies, options.DryRun, options.Parallel, palette, options.Verbose);
 

--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -111,6 +111,7 @@ $@"{p.Default}Usage:{p.Reset} {p.CommandLine}<command-line>{p.Reset} {p.Option}[
  {p.Option}-l{p.Default},{p.Reset} {p.Option}--list-targets{p.Reset}         {p.Default}List all (or specified) targets, then exit{p.Reset}
  {p.Option}-t{p.Default},{p.Reset} {p.Option}--list-tree{p.Reset}            {p.Default}List all (or specified) targets and dependency trees, then exit{p.Reset}
  {p.Option}-N{p.Default},{p.Reset} {p.Option}--no-color{p.Reset}             {p.Default}Disable colored output{p.Reset}
+ {p.Option}-E{p.Default},{p.Reset} {p.Option}--no-extended-chars{p.Reset}    {p.Default}Disable extended characters{p.Reset}
  {p.Option}-p{p.Default},{p.Reset} {p.Option}--parallel{p.Reset}             {p.Default}Run targets in parallel{p.Reset}
  {p.Option}-s{p.Default},{p.Reset} {p.Option}--skip-dependencies{p.Reset}    {p.Default}Do not run targets' dependencies{p.Reset}
  {p.Option}-v{p.Default},{p.Reset} {p.Option}--verbose{p.Reset}              {p.Default}Enable verbose output{p.Reset}

--- a/Bullseye/Internal/Palette.cs
+++ b/Bullseye/Internal/Palette.cs
@@ -5,7 +5,7 @@ namespace Bullseye.Internal
 
     public class Palette
     {
-        public Palette(bool noColor, Host host, OperatingSystem operatingSystem)
+        public Palette(bool noColor, bool noExtendedChars, Host host, OperatingSystem operatingSystem)
         {
             var reset = noColor ? "" : "\x1b[0m";
 
@@ -119,6 +119,14 @@ namespace Bullseye.Internal
             if (host == Host.VisualStudioCode)
             {
                 this.Target = blue;
+            }
+
+            if (noExtendedChars)
+            {
+                this.TreeCorner = "  ";
+                this.TreeFork = "  ";
+                this.TreeDown = "  ";
+                this.Dash = '-';
             }
         }
 

--- a/Bullseye/Options.cs
+++ b/Bullseye/Options.cs
@@ -23,6 +23,7 @@ namespace Bullseye
             new OptionDefinition("-l", "--list-targets",      "List all (or specified) targets, then exit"),
             new OptionDefinition("-t", "--list-tree",         "List all (or specified) targets and dependency trees, then exit"),
             new OptionDefinition("-N", "--no-color",          "Disable colored output"),
+            new OptionDefinition("-E", "--no-extended-chars", "Disable extended characters"),
             new OptionDefinition("-p", "--parallel",          "Run targets in parallel"),
             new OptionDefinition("-s", "--skip-dependencies", "Do not run targets' dependencies"),
             new OptionDefinition("-v", "--verbose",           "Enable verbose output"),
@@ -80,6 +81,10 @@ namespace Bullseye
                     case "-N":
                     case "--no-color":
                         this.NoColor = isSet;
+                        break;
+                    case "-E":
+                    case "--no-extended-chars":
+                        this.NoExtendedChars = isSet;
                         break;
                     case "-p":
                     case "--parallel":
@@ -184,6 +189,11 @@ namespace Bullseye
         /// Gets or sets a value which indicates whether to disable colored input.
         /// </summary>
         public bool NoColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value which indicates whether to disable extended characters.
+        /// </summary>
+        public bool NoExtendedChars { get; set; }
 
         /// <summary>
         /// Gets or sets a value which indicates whether to run targets in parallel.

--- a/BullseyeTests/LoggerTests.cs
+++ b/BullseyeTests/LoggerTests.cs
@@ -17,7 +17,7 @@ namespace BullseyeTests
         public void Timings(double elapsed, string expectedSubstring, Logger log, StringWriter writer)
         {
             "Given a logger"
-                .x(() => log = new Logger(writer = new StringWriter(), default, default, default, default, new Palette(default, default, default), default));
+                .x(() => log = new Logger(writer = new StringWriter(), default, default, default, default, new Palette(default, default, default, default), default));
 
             $"When logging a message with an elapsed time in milliseconds of {elapsed}"
                 .x(() => log.Succeeded("foo", elapsed));

--- a/BullseyeTests/api.txt
+++ b/BullseyeTests/api.txt
@@ -37,6 +37,7 @@ namespace Bullseye
         public bool ListTargets { get; set; }
         public bool ListTree { get; set; }
         public bool NoColor { get; set; }
+        public bool NoExtendedChars { get; set; }
         public bool Parallel { get; set; }
         public bool ShowHelp { get; }
         public bool SkipDependencies { get; set; }


### PR DESCRIPTION
```
-E, --no-extended-chars    Disable extended characters
```

![image](https://user-images.githubusercontent.com/677704/71485873-496f3e80-280b-11ea-8ed0-4fc971259e25.png)
