### PR TITLE
timing rounding is sometimes incorrect

### DIFF
--- a/Bullseye/Internal/TimeSpanExtensions.cs
+++ b/Bullseye/Internal/TimeSpanExtensions.cs
@@ -16,31 +16,30 @@ namespace Bullseye.Internal
         public static string Humanize(this TimeSpan duration)
         {
             // less than one millisecond
-            if (duration.TotalMilliseconds < 1D)
+            if (Convert.ToInt64(duration.TotalMilliseconds) < 1L)
             {
                 return "<1 ms";
             }
 
             // milliseconds
-            if (duration.TotalSeconds < 1D)
+            if (Convert.ToInt64(duration.TotalMilliseconds) < 1_000L)
             {
                 return duration.TotalMilliseconds.ToString("F0", provider) + " ms";
             }
 
             // seconds
-            if (duration.TotalMinutes < 1D)
+            if (Convert.ToInt64(duration.TotalSeconds * 100L) < 60_00L)
             {
                 return duration.TotalSeconds.ToString("F2", provider) + " s";
             }
 
             // minutes and seconds
-            if (duration.TotalHours < 1D)
+            if (Convert.ToInt64(duration.TotalSeconds) < 3600L)
             {
-                var minutes = Floor(duration.TotalMinutes).ToString("F0", provider);
-                var seconds = duration.Seconds.ToString("F0", provider);
-                return seconds == "0"
-                    ? $"{minutes} m"
-                    : $"{minutes} m {seconds} s";
+                var minutes = DivRem(Convert.ToInt64(duration.TotalSeconds), 60L, out var seconds);
+                return seconds == 0
+                    ? $"{minutes.ToString("F0", provider)} m"
+                    : $"{minutes.ToString("F0", provider)} m {seconds.ToString("F0", provider)} s";
             }
 
             // minutes

--- a/BullseyeTests/TimeSpanExtensionsTests.cs
+++ b/BullseyeTests/TimeSpanExtensionsTests.cs
@@ -8,20 +8,68 @@ namespace BullseyeTests
     public class TimeSpanExtensionsTests
     {
         [Scenario]
+
+        // null
         [Example(null, "")]
-        [Example(0.9D, "<1 ms")]
-        [Example(1D, "1 ms")]
-        [Example(1.234D, "1 ms")]
-        [Example(123.4D, "123 ms")]
-        [Example(1_000D, "1.00 s")]
-        [Example(1_234D, "1.23 s")]
-        [Example(12_340D, "12.34 s")]
-        [Example(60_000D, "1 m")]
-        [Example(61_234D, "1 m 1 s")]
-        [Example(3_599_999D, "59 m 59 s")]
-        [Example(3_600_000D, "60 m")]
-        [Example(3_612_345D, "60 m")]
-        [Example(3_661_234D, "61 m")]
+
+        // negative
+        [Example(-1.2345D, "<1 ms")]
+
+        // boundary
+        [Example(0.5000D, "<1 ms")]
+        [Example(0.5001D, "1 ms")]
+
+        // magnitude
+        [Example(1.0000D, "1 ms")]
+        [Example(1.2345D, "1 ms")]
+        [Example(4.5678D, "5 ms")]
+
+        // magnitude
+        [Example(10.0000D, "10 ms")]
+        [Example(12.3456D, "12 ms")]
+        [Example(34.5678D, "35 ms")]
+
+        // magnitude
+        [Example(100.0000D, "100 ms")]
+        [Example(123.4567D, "123 ms")]
+        [Example(234.5678D, "235 ms")]
+
+        // boundary
+        [Example(999.4999D, "999 ms")]
+        [Example(999.5000D, "1.00 s")]
+
+        // magnitude
+        [Example(1_000.0000D, "1.00 s")]
+        [Example(1_234.5678D, "1.23 s")]
+        [Example(2_345.6789D, "2.35 s")]
+
+        // magnitude
+        [Example(10_000.0000D, "10.00 s")]
+        [Example(11_234.5678D, "11.23 s")]
+        [Example(23_456.7891D, "23.46 s")]
+
+        // boundary
+        [Example(59_994.9999D, "59.99 s")]
+        [Example(59_995.0000D, "1 m")]
+
+        // magnitude
+        [Example(60_000.0000D, "1 m")]
+        [Example(61_234.5678D, "1 m 1 s")]
+        [Example(64_567.8912D, "1 m 5 s")]
+
+        // magnitude
+        [Example(600_000.0000D, "10 m")]
+        [Example(612_345.6789D, "10 m 12 s")]
+        [Example(634_567.8912D, "10 m 35 s")]
+
+        // boundary
+        [Example(3_599_499.9999D, "59 m 59 s")]
+        [Example(3_599_500.0000D, "60 m")]
+
+        // magnitude
+        [Example(3_600_000.0000D, "60 m")]
+        [Example(3_612_234.5678D, "60 m")]
+        [Example(3_634_567.8912D, "61 m")]
         public void Humanization(double? milliseconds, string expected, TimeSpan? timeSpan, string actual)
         {
             $"Given a timespan of {milliseconds} milliseconds"

--- a/BullseyeTests/log.txt
+++ b/BullseyeTests/log.txt
@@ -144,7 +144,7 @@ logPrefix2: badInputsTarget   Failed!     1.24 s    1.6%
 logPrefix2:   goodInput1      Succeeded     1.23 s    1.6%
 logPrefix2:   badInput        Failed!       1 ms      0.0%
 logPrefix2: ----------------------------------------------
-logPrefix2: Succeeded (target1 target2 target3) (1 m 18 s)
+logPrefix2: Succeeded (target1 target2 target3) (1 m 19 s)
 logPrefix2: ----------------------------------------------
 logPrefix2: Target            Outcome     Duration        
 logPrefix2: ----------------  ----------  ----------------
@@ -161,7 +161,7 @@ logPrefix2: badInputsTarget   Failed!     1.24 s    1.6%
 logPrefix2:   goodInput1      Succeeded     1.23 s    1.6%
 logPrefix2:   badInput        Failed!       1 ms      0.0%
 logPrefix2: ----------------------------------------------
-logPrefix2: Failed! (target1 target2 target3) (1 m 18 s)
+logPrefix2: Failed! (target1 target2 target3) (1 m 19 s)
 
 noColor: True
 noExtendedChars: False


### PR DESCRIPTION
e.g. 1 m 14 s, 3.58 s, and 1.24 s add up to 78.82 seconds, which is 1 m 19 s, not 1 m 18 s (see `log.txt`)