### PR TITLE
running targets without exiting leaves the console screen buffer output mode changed

### DIFF
--- a/Bullseye/Internal/IAsyncDisposable.cs
+++ b/Bullseye/Internal/IAsyncDisposable.cs
@@ -1,0 +1,10 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Bullseye.Internal
+{
+    using System.Threading.Tasks;
+
+    public interface IAsyncDisposable
+    {
+        Task DisposeAsync();
+    }
+}

--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -64,8 +64,20 @@ namespace Bullseye.Internal
                             ? OperatingSystem.MacOS
                             : OperatingSystem.Unknown;
 
-            await Terminal.TryConfigure(options.NoColor, operatingSystem, options.Verbose ? Console.Error : NullTextWriter.Instance, logPrefix).Tax();
+            var terminal = await Terminal.TryConfigure(options.NoColor, operatingSystem, options.Verbose ? Console.Error : NullTextWriter.Instance, logPrefix).Tax();
 
+            try
+            {
+                await RunAsync(targets, names, options, messageOnly, logPrefix, exit, logArgs, operatingSystem).Tax();
+            }
+            finally
+            {
+                await terminal.DisposeAsync().Tax();
+            }
+        }
+
+        private static async Task RunAsync(TargetCollection targets, List<string> names, Options options, Func<Exception, bool> messageOnly, string logPrefix, bool exit, Func<Logger, Task> logArgs, OperatingSystem operatingSystem)
+        {
             var (host, isHostDetected) = options.Host.DetectIfUnknown();
 
             var palette = new Palette(options.NoColor, options.NoExtendedChars, host, operatingSystem);

--- a/Bullseye/Internal/Terminal.cs
+++ b/Bullseye/Internal/Terminal.cs
@@ -1,33 +1,55 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace Bullseye.Internal
 {
+    using System;
     using System.IO;
     using System.Threading.Tasks;
 
     public static class Terminal
     {
-        public static async Task TryConfigure(bool noColor, OperatingSystem operatingSystem, TextWriter log, string logPrefix)
+        public static async Task<IAsyncDisposable> TryConfigure(bool noColor, OperatingSystem operatingSystem, TextWriter log, string logPrefix)
         {
             if (noColor || operatingSystem != OperatingSystem.Windows)
             {
-                return;
+                return new NullAsyncDisposable();
             }
 
             var (handle, gotHandle) = await NativeMethodsWrapper.TryGetStandardOutputHandle(log, logPrefix).Tax();
             if (!gotHandle)
             {
-                return;
+                return new NullAsyncDisposable();
             }
 
-            var (mode, gotMode) = await NativeMethodsWrapper.TryGetConsoleScreenBufferOutputMode(handle, log, logPrefix).Tax();
+            var (oldMode, gotMode) = await NativeMethodsWrapper.TryGetConsoleScreenBufferOutputMode(handle, log, logPrefix).Tax();
             if (!gotMode)
             {
-                return;
+                return new NullAsyncDisposable();
             }
 
-            mode |= NativeMethods.ConsoleOutputModes.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            var newMode = oldMode | NativeMethods.ConsoleOutputModes.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
-            await NativeMethodsWrapper.TrySetConsoleScreenBufferOutputMode(handle, mode, log, logPrefix).Tax();
+            await NativeMethodsWrapper.TrySetConsoleScreenBufferOutputMode(handle, newMode, log, logPrefix).Tax();
+
+            return new State(handle, oldMode, log, logPrefix);
+        }
+
+        private class State : IAsyncDisposable
+        {
+            private readonly IntPtr handle;
+            private readonly NativeMethods.ConsoleOutputModes oldMode;
+            private readonly TextWriter log;
+            private readonly string logPrefix;
+
+            public State(IntPtr handle, NativeMethods.ConsoleOutputModes oldMode, TextWriter log, string logPrefix) =>
+                (this.handle, this.oldMode, this.log, this.logPrefix) = (handle, oldMode, log, logPrefix);
+
+            public Task DisposeAsync() =>
+                NativeMethodsWrapper.TrySetConsoleScreenBufferOutputMode(handle, oldMode, log, logPrefix);
+        }
+
+        private class NullAsyncDisposable : IAsyncDisposable
+        {
+            public Task DisposeAsync() => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Version(s)

`1.2.0` to `3.5.0`.

## To reproduce

Steps to reproduce the behavior:

1. Use Windows
1. Ensure the console screen buffer output mode is set to something other than 7.
1. Call `RunTargetsWithoutExiting` without the `--no-color` option.

## Expected behavior

The console screen buffer output mode is the same as before calling the method.

## Actual behaviour

The console screen buffer output mode is 7.

## Workarounds

Record the original console screen buffer output mode before calling the method and reset it after calling the method.