### PR TITLE
Options.NoColor XML doc says "input" instead of "output"

### DIFF
--- a/Bullseye/Options.cs
+++ b/Bullseye/Options.cs
@@ -195,7 +195,7 @@ namespace Bullseye
         public bool ListTree { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to disable colored input.
+        /// Gets or sets a value indicating whether to disable colored output.
         /// </summary>
         public bool NoColor { get; set; }
 


### PR DESCRIPTION
## Version(s)

3.2.0 - 3.6.0.

## To reproduce

Steps to reproduce the behaviour:

1. Open a C# project
2. Add a reference to Bullseye
3. Somewhere in a method, type `new Options().NoColor`

## Expected behaviour

Intellisense shows:

> Gets or sets a value indicating whether to disable colored output.

## Actual behaviour

Intellisense shows:

> Gets or sets a value indicating whether to disable colored input.

## Workarounds

Know that the property relates to coloured output and not input, and get on with life.
