### PR TITLE
Add xenial-io to the list of bullseye users

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ To name a few:
 - [Tasty](https://github.com/xenial-io/Tasty)
 - [TemplatedConfiguration](https://github.com/Erwinvandervalk/TemplatedConfiguration)
 - [xBehave.net](https://github.com/xbehave)
+- [Xenial](https://github.com/xenial-io)
 
 Feel free to send a pull request to add your repo or organisation to this list!
 


### PR DESCRIPTION
Because I use bullseye in almost every project, I added the whole org to the usage list.