### PR TITLE
Fix RunTargetsWithoutExiting static method async call

### DIFF
--- a/Bullseye/Targets.Static.cs
+++ b/Bullseye/Targets.Static.cs
@@ -133,7 +133,7 @@ namespace Bullseye
         /// If the entry assembly is <c>null</c>, the default prefix of "Bullseye" is used.
         /// </param>
         public static void RunTargetsWithoutExiting(IEnumerable<string> targets, Options options, Func<Exception, bool> messageOnly = null, string logPrefix = null) =>
-            instance.RunWithoutExitingAsync(targets, options, messageOnly, logPrefix);
+            instance.RunWithoutExiting(targets, options, messageOnly, logPrefix);
 
         /// <summary>
         /// Runs the previously specified targets.


### PR DESCRIPTION
Currently, the method returns before it is done running targets. The `void` swallows up the Task emitted from RunWithoutExitingAsync, so this happens silently. The other RunTargets methods look correct, so I assume it's just a typo.