### PR TITLE
Improve parallel execution behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vs/
+.vscode/
 bin/
 obj/
 *.user

--- a/Bullseye/Bullseye.csproj
+++ b/Bullseye/Bullseye.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bullseye/Internal/Logger.cs
+++ b/Bullseye/Internal/Logger.cs
@@ -53,7 +53,7 @@ namespace Bullseye.Internal
             }
         }
 
-        public async Task Verbose(Stack<string> targets, string message)
+        public async Task Verbose(IEnumerable<string> targets, string message)
         {
             if (this.verbose)
             {
@@ -261,7 +261,7 @@ namespace Bullseye.Internal
 
         private string Message(string color, string text) => $"{GetPrefix()}{color}{text}{p.Reset}";
 
-        private string Message(Stack<string> targets, string color, string text) => $"{GetPrefix(targets)}{color}{text}{p.Reset}";
+        private string Message(IEnumerable<string> targets, string color, string text) => $"{GetPrefix(targets)}{color}{text}{p.Reset}";
 
         private string Message(string color, string text, IEnumerable<string> targets, TimeSpan? duration) =>
             $"{GetPrefix()}{color}{text}{p.Reset} {p.Target}({targets.Spaced()}){p.Reset}{GetSuffix(false, duration)}{p.Reset}";
@@ -281,7 +281,7 @@ namespace Bullseye.Internal
         private string GetPrefix() =>
             $"{p.Prefix}{prefix}:{p.Reset} ";
 
-        private string GetPrefix(Stack<string> targets) =>
+        private string GetPrefix(IEnumerable<string> targets) =>
             $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{string.Join($"{p.Default}/{p.Target}", targets.Reverse())}{p.Default}:{p.Reset} ";
 
         private string GetPrefix(string target) =>


### PR DESCRIPTION
Two changes to the parallel execution behavior, one bug fix and one performance improvement.

- Bug fix: change the Stack in RunAsync to be an ImmutableStack instead. Currently, the mutable stack is not synchronized between threads, so its contents don't match the actual dependency path. It can also throw an exception from modification during enumeration in the logger. An ImmutableStack is a purely functional data structure and accomplishes the goal here.
- Performance improvement: only walk a target's dependencies once. The current behavior is to explore every path through the dependency DAG. This leads to exponential runtime under multiple diamond dependencies. For example, consider the following pathological case:
  ```
  var targets = new List<string>();
  for (var i = 0; i < 30; i++)
  {
      Target(i.ToString(), targets.TakeLast(2), () => { });
      targets.Add(i.ToString());
  }
  Target("default", DependsOn(targets.Last()));
  RunTargetsAndExit(new[] { "-v", "-p" });
  ```
  Currently, this won't halt in our lifetimes. With the change, it runs instantly.