### PR TITLE
avoid walking the dependencies of a target more than once

### DIFF
--- a/Bullseye/Internal/TargetCollection.cs
+++ b/Bullseye/Internal/TargetCollection.cs
@@ -62,6 +62,13 @@ namespace Bullseye.Internal
                     return;
                 }
 
+                if (runningTargets.TryGetValue(name, out var runningTarget))
+                {
+                    await log.Verbose(dependencyStack, "Awaiting...").Tax();
+                    await runningTarget.Tax();
+                    return;
+                }
+
                 await log.Verbose(dependencyStack, "Walking dependencies...").Tax();
 
                 var target = this[name];


### PR DESCRIPTION
Cherry-picked (and amended) from https://github.com/adamralph/bullseye/pull/619.

Thanks @alibresco!

closes https://github.com/adamralph/bullseye/issues/622