### PR TITLE
avoid redundantly awaiting targets

### DIFF
--- a/Bullseye/Internal/TaskExtensions.cs
+++ b/Bullseye/Internal/TaskExtensions.cs
@@ -8,5 +8,7 @@ namespace Bullseye.Internal
         public static ConfiguredTaskAwaitable Tax(this Task task) => task.ConfigureAwait(false);
 
         public static ConfiguredTaskAwaitable<TResult> Tax<TResult>(this Task<TResult> task) => task.ConfigureAwait(false);
+
+        public static bool IsAwaitable(this Task task) => !task.IsCanceled && !task.IsFaulted && !task.IsCompleted;
     }
 }

--- a/BullseyeTests/Dependencies.cs
+++ b/BullseyeTests/Dependencies.cs
@@ -161,6 +161,7 @@ namespace BullseyeTests
             Assert.Equal("second", ran[1]);
             Assert.Equal("third", ran[2]);
             _ = Assert.Single(Regex.Matches(diagnostics, "first: Walking dependencies..."));
+            _ = Assert.Single(Regex.Matches(diagnostics, "first: Awaiting..."));
         }
 
         [Fact]


### PR DESCRIPTION
## Use case(s)

When a target is depended on by more than one target, there is no need to walk the dependencies of that target multiple times.

## Description

For example:

```c#
using static Bullseye.Targets;

Target("a", () => { });
Target("b", DependsOn("a"), () => { });
Target("default", DependsOn("b", "a"));

RunTargetsAndExit(args);
```

When run with the `--verbosity` option:

### Before

<img src="https://user-images.githubusercontent.com/677704/128061749-62ada077-454d-4f42-9934-8edf7e16edc4.png" width="434px" />

### After

<img src="https://user-images.githubusercontent.com/677704/128061920-b44a71d5-c6e0-4a2e-a238-e647ba8f44c7.png" width="434px" />

A side effect is that the "Awaiting..." log message comes after the "Starting..." log message and may even sometimes appear after the "Succeeded" or "Failed" message as can been seen with the `default` target. These diagnostics not contractual, so this is regarding as non-breaking. If anything, the diagnostics are now more accurate, since the awaiting is indeed done in after making the task available for scheduling, and the execution of the task and the await are potentially done in different task execution contexts.
