### PR TITLE
allow forcing of console (default) mode

### DIFF
--- a/Bullseye/Host.cs
+++ b/Bullseye/Host.cs
@@ -3,7 +3,7 @@ namespace Bullseye
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public enum Host
     {
-        Unknown,
+        Console,
         Appveyor,
         AzurePipelines,
         GitHubActions,

--- a/Bullseye/Internal/HostExtensions.cs
+++ b/Bullseye/Internal/HostExtensions.cs
@@ -4,11 +4,11 @@ namespace Bullseye.Internal
 {
     public static class HostExtensions
     {
-        public static Host DetectIfUnknown(this Host host)
+        public static Host DetectIfNull(this Host? host)
         {
-            if (host != Host.Unknown)
+            if (host.HasValue)
             {
-                return host;
+                return host.Value;
             }
 
             if (Environment.GetEnvironmentVariable("APPVEYOR")?.ToUpperInvariant() == "TRUE")
@@ -40,7 +40,7 @@ namespace Bullseye.Internal
                 return Host.VisualStudioCode;
             }
 
-            return Host.Unknown;
+            return Host.Console;
         }
     }
 }

--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -73,7 +73,7 @@ namespace Bullseye.Internal
 
             var builder = new StringBuilder()
                 .AppendLine(Format($"{this.palette.Verbose}{version}{this.palette.Reset}", "Bullseye version", this.prefix, this.palette))
-                .AppendLine(Format($"{this.palette.Verbose}{this.host}{(this.host != Host.Unknown ? $" ({(this.hostForced ? "forced" : "detected")})" : "")}{this.palette.Reset}", "Host", this.prefix, this.palette))
+                .AppendLine(Format($"{this.palette.Verbose}{this.host} ({(this.hostForced ? "forced" : "detected")}){this.palette.Reset}", "Host", this.prefix, this.palette))
                 .AppendLine(Format($"{this.palette.Verbose}{this.operatingSystem}{this.palette.Reset}", "OS", this.prefix, this.palette))
                 .AppendLine(Format($"{this.palette.Verbose}{string.Join(" ", this.args)}{this.palette.Reset}", "Args", this.prefix, this.palette));
 
@@ -253,6 +253,7 @@ $@"{p.Default}Usage:{p.Reset}
   {p.Option}-v{p.Default},{p.Reset} {p.Option}--verbose{p.Reset}              {p.Default}Enable verbose output{p.Reset}
   {p.Option}--appveyor{p.Reset}                 {p.Default}Force Appveyor mode (normally auto-detected){p.Reset}
   {p.Option}--azure-pipelines{p.Reset}          {p.Default}Force Azure Pipelines mode (normally auto-detected){p.Reset}
+  {p.Option}--console{p.Reset}                  {p.Default}Force console mode (normally auto-detected){p.Reset}
   {p.Option}--github-actions{p.Reset}           {p.Default}Force GitHub Actions mode (normally auto-detected){p.Reset}
   {p.Option}--gitlab-ci{p.Reset}                {p.Default}Force GitLab CI mode (normally auto-detected){p.Reset}
   {p.Option}--teamcity{p.Reset}                 {p.Default}Force TeamCity mode (normally auto-detected){p.Reset}

--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -117,7 +117,7 @@ namespace Bullseye.Internal
                 noColor = true;
             }
 
-            var host = options.Host.DetectIfUnknown();
+            var host = options.Host.DetectIfNull();
 
             var operatingSystem =
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -133,7 +133,7 @@ namespace Bullseye.Internal
                 args,
                 options.DryRun,
                 host,
-                options.Host != Host.Unknown,
+                options.Host.HasValue,
                 noColor,
                 options.NoExtendedChars,
                 operatingSystem,

--- a/Bullseye/Options.cs
+++ b/Bullseye/Options.cs
@@ -30,6 +30,7 @@ namespace Bullseye
             new OptionDefinition("-v", "--verbose",           "Enable verbose output"),
             new OptionDefinition(null, "--appveyor",          "Force Appveyor mode (normally auto-detected)"),
             new OptionDefinition(null, "--azure-pipelines",   "Force Azure Pipelines mode (normally auto-detected)"),
+            new OptionDefinition(null, "--console",           "Force console mode (normally auto-detected)"),
             new OptionDefinition(null, "--github-actions",    "Force GitHub Actions mode (normally auto-detected)"),
             new OptionDefinition(null, "--gitlab-ci",         "Force GitLab CI mode (normally auto-detected)"),
             new OptionDefinition(null, "--teamcity",          "Force TeamCity mode (normally auto-detected)"),
@@ -102,42 +103,49 @@ namespace Bullseye
                     case "--appveyor":
                         if (isSet)
                         {
-                            this.Host = Host.Appveyor;
+                            this.Host = Bullseye.Host.Appveyor;
                         }
 
                         break;
                     case "--azure-pipelines":
                         if (isSet)
                         {
-                            this.Host = Host.AzurePipelines;
+                            this.Host = Bullseye.Host.AzurePipelines;
+                        }
+
+                        break;
+                    case "--console":
+                        if (isSet)
+                        {
+                            this.Host = Bullseye.Host.Console;
                         }
 
                         break;
                     case "--github-actions":
                         if (isSet)
                         {
-                            this.Host = Host.GitHubActions;
+                            this.Host = Bullseye.Host.GitHubActions;
                         }
 
                         break;
                     case "--gitlab-ci":
                         if (isSet)
                         {
-                            this.Host = Host.GitLabCI;
+                            this.Host = Bullseye.Host.GitLabCI;
                         }
 
                         break;
                     case "--travis":
                         if (isSet)
                         {
-                            this.Host = Host.Travis;
+                            this.Host = Bullseye.Host.Travis;
                         }
 
                         break;
                     case "--teamcity":
                         if (isSet)
                         {
-                            this.Host = Host.TeamCity;
+                            this.Host = Bullseye.Host.TeamCity;
                         }
 
                         break;
@@ -227,9 +235,9 @@ namespace Bullseye
 
         /// <summary>
         /// Gets or sets a value indicating whether to force the mode for a specific host environment (normally auto-detected).
-        /// If the value is set to <see cref="Host.Unknown"/> (default), then no mode is forced.
+        /// If the value is set to <c>null</c>, then no mode is forced.
         /// </summary>
-        public Host Host { get; set; }
+        public Host? Host { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether to show help and exit.

--- a/Bullseye/PublicAPI.Shipped.txt
+++ b/Bullseye/PublicAPI.Shipped.txt
@@ -1,11 +1,11 @@
 Bullseye.Host
 Bullseye.Host.Appveyor = 1 -> Bullseye.Host
 Bullseye.Host.AzurePipelines = 2 -> Bullseye.Host
+Bullseye.Host.Console = 0 -> Bullseye.Host
 Bullseye.Host.GitHubActions = 3 -> Bullseye.Host
 Bullseye.Host.GitLabCI = 4 -> Bullseye.Host
 Bullseye.Host.TeamCity = 6 -> Bullseye.Host
 Bullseye.Host.Travis = 5 -> Bullseye.Host
-Bullseye.Host.Unknown = 0 -> Bullseye.Host
 Bullseye.Host.VisualStudioCode = 7 -> Bullseye.Host
 Bullseye.InvalidUsageException
 Bullseye.InvalidUsageException.InvalidUsageException() -> void
@@ -21,7 +21,7 @@ Bullseye.Options.Clear.get -> bool
 Bullseye.Options.Clear.set -> void
 Bullseye.Options.DryRun.get -> bool
 Bullseye.Options.DryRun.set -> void
-Bullseye.Options.Host.get -> Bullseye.Host
+Bullseye.Options.Host.get -> Bullseye.Host?
 Bullseye.Options.Host.set -> void
 Bullseye.Options.ListDependencies.get -> bool
 Bullseye.Options.ListDependencies.set -> void

--- a/BullseyeTests/output.txt
+++ b/BullseyeTests/output.txt
@@ -1,7 +1,7 @@
 ﻿
 noColor: True
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Unknown
 skipDependencies: True
@@ -11,7 +11,7 @@ verbose: True
 args: arg1 arg2
 
 prefix1: Bullseye version: version
-prefix1: Host: Unknown
+prefix1: Host: Console (forced)
 prefix1: OS: Unknown
 prefix1: Args: arg1 arg2
 prefix1: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -87,7 +87,7 @@ prefix1: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: True
-host: Unknown
+host: Console
 hostForced: False
 operatingSystem: Unknown
 skipDependencies: False
@@ -97,7 +97,7 @@ verbose: True
 args: arg1 arg2
 
 prefix2: Bullseye version: version
-prefix2: Host: Unknown
+prefix2: Host: Console (detected)
 prefix2: OS: Unknown
 prefix2: Args: arg1 arg2
 prefix2: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -173,7 +173,7 @@ prefix2: FAILED! (target1 target2 target3) (1 m 19 s)
 
 noColor: True
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Unknown
 skipDependencies: True
@@ -183,7 +183,7 @@ verbose: True
 args: 
 
 prefix3: Bullseye version: version
-prefix3: Host: Unknown
+prefix3: Host: Console (forced)
 prefix3: OS: Unknown
 prefix3: Args: 
 prefix3: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -259,7 +259,7 @@ prefix3: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Windows
 skipDependencies: True
@@ -269,7 +269,7 @@ verbose: True
 args: 
 
 prefix4: Bullseye version: version
-prefix4: Host: Unknown
+prefix4: Host: Console (forced)
 prefix4: OS: Windows
 prefix4: Args: 
 prefix4: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -345,7 +345,7 @@ prefix4: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Linux
 skipDependencies: True
@@ -355,7 +355,7 @@ verbose: True
 args: 
 
 prefix5: Bullseye version: version
-prefix5: Host: Unknown
+prefix5: Host: Console (forced)
 prefix5: OS: Linux
 prefix5: Args: 
 prefix5: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -431,7 +431,7 @@ prefix5: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: MacOS
 skipDependencies: True
@@ -441,7 +441,7 @@ verbose: True
 args: 
 
 prefix6: Bullseye version: version
-prefix6: Host: Unknown
+prefix6: Host: Console (forced)
 prefix6: OS: MacOS
 prefix6: Args: 
 prefix6: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -2925,7 +2925,7 @@ prefix34: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenc
 
 noColor: False
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Unknown
 skipDependencies: True
@@ -2935,7 +2935,7 @@ verbose: True
 args: 
 
 [90mprefix35:[0m [90mBullseye version:[0m [90mversion[0m
-[90mprefix35:[0m [90mHost:[0m [90mUnknown[0m
+[90mprefix35:[0m [90mHost:[0m [90mConsole (forced)[0m
 [90mprefix35:[0m [90mOS:[0m [90mUnknown[0m
 [90mprefix35:[0m [90mArgs:[0m [90m[0m
 [90mprefix35:[0m [36mverboseTarget3[37m:[0m [90mAwaiting[0m [90m(/verboseTarget1/verboseTarget2/verboseTarget3)[0m
@@ -3011,7 +3011,7 @@ args:
 
 noColor: False
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Windows
 skipDependencies: True
@@ -3021,7 +3021,7 @@ verbose: True
 args: 
 
 [90mprefix36:[0m [90mBullseye version:[0m [90mversion[0m
-[90mprefix36:[0m [90mHost:[0m [90mUnknown[0m
+[90mprefix36:[0m [90mHost:[0m [90mConsole (forced)[0m
 [90mprefix36:[0m [90mOS:[0m [90mWindows[0m
 [90mprefix36:[0m [90mArgs:[0m [90m[0m
 [90mprefix36:[0m [36mverboseTarget3[37m:[0m [90mAwaiting[0m [90m(/verboseTarget1/verboseTarget2/verboseTarget3)[0m
@@ -3097,7 +3097,7 @@ args:
 
 noColor: False
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: Linux
 skipDependencies: True
@@ -3107,7 +3107,7 @@ verbose: True
 args: 
 
 [90mprefix37:[0m [90mBullseye version:[0m [90mversion[0m
-[90mprefix37:[0m [90mHost:[0m [90mUnknown[0m
+[90mprefix37:[0m [90mHost:[0m [90mConsole (forced)[0m
 [90mprefix37:[0m [90mOS:[0m [90mLinux[0m
 [90mprefix37:[0m [90mArgs:[0m [90m[0m
 [90mprefix37:[0m [36mverboseTarget3[37m:[0m [90mAwaiting[0m [90m(/verboseTarget1/verboseTarget2/verboseTarget3)[0m
@@ -3183,7 +3183,7 @@ args:
 
 noColor: False
 noExtendedChars: False
-host: Unknown
+host: Console
 hostForced: True
 operatingSystem: MacOS
 skipDependencies: True
@@ -3193,7 +3193,7 @@ verbose: True
 args: 
 
 [90mprefix38:[0m [90mBullseye version:[0m [90mversion[0m
-[90mprefix38:[0m [90mHost:[0m [90mUnknown[0m
+[90mprefix38:[0m [90mHost:[0m [90mConsole (forced)[0m
 [90mprefix38:[0m [90mOS:[0m [90mMacOS[0m
 [90mprefix38:[0m [90mArgs:[0m [90m[0m
 [90mprefix38:[0m [36mverboseTarget3[37m:[0m [90mAwaiting[0m [90m(/verboseTarget1/verboseTarget2/verboseTarget3)[0m


### PR DESCRIPTION
Adds a `--console` option to force console mode instead of allowing auto-detection of Appveyor, Azure Pipelines, GitHub Actions, GitLab CI, TeamCity, or Travis CI.

Breaking, because:

- `Host.Unknown` is renamed to `Host.Console`
- The type of 'Options.Host` is changed from `Host` to `Host?`