### PR TITLE
switch from netstandard2.0 to netstandard2.1

### DIFF
--- a/Bullseye/Bullseye.csproj
+++ b/Bullseye/Bullseye.csproj
@@ -10,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/adamralph/bullseye/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Bullseye/Internal/NativeMethodsWrapper.cs
+++ b/Bullseye/Internal/NativeMethodsWrapper.cs
@@ -9,7 +9,7 @@ namespace Bullseye.Internal
     {
         public static async Task<(IntPtr handle, bool succeeded)> TryGetStandardOutputHandle(TextWriter diagnostics, string messagePrefix)
         {
-            diagnostics = diagnostics ?? Console.Error;
+            diagnostics ??= Console.Error;
 
             var (handle, error) = (NativeMethods.GetStdHandle(NativeMethods.StdHandle.STD_OUTPUT_HANDLE), Marshal.GetLastWin32Error());
 
@@ -25,7 +25,7 @@ namespace Bullseye.Internal
 
         public static async Task<(NativeMethods.ConsoleOutputModes mode, bool succeeded)> TryGetConsoleScreenBufferOutputMode(IntPtr standardOutputHandle, TextWriter diagnostics, string messagePrefix)
         {
-            diagnostics = diagnostics ?? Console.Error;
+            diagnostics ??= Console.Error;
 
             if (!NativeMethods.GetConsoleMode(standardOutputHandle, out var mode))
             {
@@ -39,7 +39,7 @@ namespace Bullseye.Internal
 
         public static async Task TrySetConsoleScreenBufferOutputMode(IntPtr standardOutputHandle, NativeMethods.ConsoleOutputModes mode, TextWriter diagnostics, string messagePrefix)
         {
-            diagnostics = diagnostics ?? Console.Error;
+            diagnostics ??= Console.Error;
 
             if (!NativeMethods.SetConsoleMode(standardOutputHandle, mode))
             {

--- a/Bullseye/Internal/Output.Palette.cs
+++ b/Bullseye/Internal/Output.Palette.cs
@@ -174,7 +174,7 @@ namespace Bullseye.Internal
 
                 foreach (var number in numbers)
                 {
-                    text = text.Replace($"\x1b[{number}m", "");
+                    text = text.Replace($"\x1b[{number}m", "", StringComparison.Ordinal);
                 }
 
                 return text;

--- a/Bullseye/Internal/Output.Results.cs
+++ b/Bullseye/Internal/Output.Results.cs
@@ -115,7 +115,7 @@ namespace Bullseye.Internal
             return builder.ToString();
 
             // pad right printed
-            string Prp(string text, int totalWidth, char paddingChar) =>
+            static string Prp(string text, int totalWidth, char paddingChar) =>
                 text.PadRight(totalWidth + (text.Length - Palette.StripColours(text).Length), paddingChar);
         }
 

--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -320,7 +320,7 @@ $@"{p.Default}Usage:{p.Reset}
                     {
                         var prefix = isRoot
                             ? startingPrefix ?? ""
-                            : $"{previousPrefix.Replace(p.TreeCorner, "  ").Replace(p.TreeFork, p.TreeDown)}{(item.index == names.Count - 1 ? p.TreeCorner : p.TreeFork)}";
+                            : $"{previousPrefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeDown, StringComparison.Ordinal)}{(item.index == names.Count - 1 ? p.TreeCorner : p.TreeFork)}";
 
                         var isMissing = !targets.Contains(item.name);
 
@@ -346,7 +346,7 @@ $@"{p.Default}Usage:{p.Reset}
                         {
                             foreach (var inputItem in hasInputs.Inputs.Select((input, index) => new { input, index }))
                             {
-                                var inputPrefix = $"{prefix.Replace(p.TreeCorner, "  ").Replace(p.TreeFork, p.TreeDown)}{(target.Dependencies.Any() && depth + 1 <= maxDepth ? p.TreeDown : "  ")}";
+                                var inputPrefix = $"{prefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeDown, StringComparison.Ordinal)}{(target.Dependencies.Any() && depth + 1 <= maxDepth ? p.TreeDown : "  ")}";
 
                                 lines.Add(($"{inputPrefix}{p.Input}{inputItem.input}{p.Reset}", null));
                             }

--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -88,9 +88,9 @@ namespace Bullseye.Internal
             TextWriter outputWriter,
             TextWriter diagnosticsWriter)
         {
-            options = options ?? new Options();
-            diagnosticsWriter = diagnosticsWriter ?? Console.Error;
-            messagePrefix = messagePrefix ?? await GetMethodPrefix(diagnosticsWriter).Tax();
+            options ??= new Options();
+            diagnosticsWriter ??= Console.Error;
+            messagePrefix ??= await GetMethodPrefix(diagnosticsWriter).Tax();
 
             if (options.Clear)
             {
@@ -184,7 +184,7 @@ namespace Bullseye.Internal
             Func<Exception, bool> messageOnly,
             Output output)
         {
-            targets = targets ?? new TargetCollection();
+            targets ??= new TargetCollection();
 
             if (unknownOptions.Count > 0)
             {


### PR DESCRIPTION
To safely and simply take advantage of new language features internally.

This is breaking since it [drops support for several platform versions](https://docs.microsoft.com/en-us/dotnet/standard/net-standard), including _all versions_ of .NET Framework. 👋

I'm doing this now because there is now an LTS successor to .NET Framework—[.NET 6](https://dotnet.microsoft.com/download/dotnet).