### PR TITLE
make Palette and HostExtensions public

### DIFF
--- a/Bullseye/Host.cs
+++ b/Bullseye/Host.cs
@@ -3,7 +3,6 @@ namespace Bullseye
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public enum Host
     {
-        Automatic,
         AppVeyor,
         Console,
         GitHubActions,

--- a/Bullseye/HostExtensions.cs
+++ b/Bullseye/HostExtensions.cs
@@ -1,14 +1,22 @@
 using System;
 
-namespace Bullseye.Internal
+namespace Bullseye
 {
+    /// <summary>
+    /// Contains extension methods for <see cref="Host"/>.
+    /// </summary>
     public static class HostExtensions
     {
-        public static Host DetectIfAutomatic(this Host host)
+        /// <summary>
+        /// Detects the host if the current host is <c>null</c>.
+        /// </summary>
+        /// <param name="host">The current host.</param>
+        /// <returns>The current or detected host.</returns>
+        public static Host DetectIfNull(this Host? host)
         {
-            if (host != Host.Automatic)
+            if (host != null)
             {
-                return host;
+                return host.Value;
             }
 
             if (Environment.GetEnvironmentVariable("APPVEYOR")?.ToUpperInvariant() == "TRUE")

--- a/Bullseye/IOptions.cs
+++ b/Bullseye/IOptions.cs
@@ -63,6 +63,6 @@ namespace Bullseye
         /// <summary>
         /// Gets a value indicating which mode to use for a specific host environment.
         /// </summary>
-        Host Host { get; }
+        Host? Host { get; }
     }
 }

--- a/Bullseye/Internal/Output.Format.cs
+++ b/Bullseye/Internal/Output.Format.cs
@@ -14,7 +14,7 @@ namespace Bullseye.Internal
             bool parallel,
             bool skipDependencies,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {message} {p.Target}({targets.Select(target => target.Name).Spaced()}){p.Reset}{(dryRun ? $" {p.Option}(dry run){p.Reset}" : "")}{(parallel ? $" {p.Option}(parallel){p.Reset}" : "")}{(skipDependencies ? $" {p.Option}(skip dependencies){p.Reset}" : "")}";
+            $"{p.Prefix}{prefix}:{p.Default} {message} {p.Target}({targets.Select(target => target.Name).Spaced()}){p.Default}{(dryRun ? $" {p.Option}(dry run){p.Default}" : "")}{(parallel ? $" {p.Option}(parallel){p.Default}" : "")}{(skipDependencies ? $" {p.Option}(skip dependencies){p.Default}" : "")}";
 
         private static string Format(
             string prefix,
@@ -25,14 +25,14 @@ namespace Bullseye.Internal
             bool skipDependencies,
             TimeSpan duration,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {message} {p.Target}({targets.Select(target => target.Name).Spaced()}){p.Reset}{(dryRun ? $" {p.Option}(dry run){p.Reset}" : "")}{(parallel ? $" {p.Option}(parallel){p.Reset}" : "")}{(skipDependencies ? $" {p.Option}(skip dependencies){p.Reset}" : "")} {p.Timing}({duration.Humanize()}){p.Reset}";
+            $"{p.Prefix}{prefix}:{p.Default} {message} {p.Target}({targets.Select(target => target.Name).Spaced()}){p.Default}{(dryRun ? $" {p.Option}(dry run){p.Default}" : "")}{(parallel ? $" {p.Option}(parallel){p.Default}" : "")}{(skipDependencies ? $" {p.Option}(skip dependencies){p.Default}" : "")} {p.Timing}({duration.Humanize()}){p.Default}";
 
         private static string Format(
             string prefix,
             Target target,
             string message,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}:{p.Reset} {message}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}:{p.Default} {message}";
 
         private static string Format(
             string prefix,
@@ -40,7 +40,7 @@ namespace Bullseye.Internal
             string message,
             IReadOnlyCollection<Target> dependencyPath,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}:{p.Reset} {message}{FormatDependencyPath(dependencyPath, p)}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}:{p.Default} {message}{FormatDependencyPath(dependencyPath, p)}";
 
         private static string Format(
             string prefix,
@@ -49,7 +49,7 @@ namespace Bullseye.Internal
             TimeSpan duration,
             IReadOnlyCollection<Target> dependencyPath,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}:{p.Reset} {message} {p.Timing}({duration.Humanize()}){p.Reset}{FormatDependencyPath(dependencyPath, p)}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}:{p.Default} {message} {p.Timing}({duration.Humanize()}){p.Default}{FormatDependencyPath(dependencyPath, p)}";
 
         private static string Format<TInput>(
             string prefix,
@@ -57,7 +57,7 @@ namespace Bullseye.Internal
             TInput input,
             string message,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}/{p.Input}{input}{p.Default}:{p.Reset} {message}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}/{p.Input}{input}{p.Text}:{p.Default} {message}";
 
         private static string Format<TInput>(
             string prefix,
@@ -66,7 +66,7 @@ namespace Bullseye.Internal
             string message,
             IReadOnlyCollection<Target> dependencyPath,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}/{p.Input}{input}{p.Default}:{p.Reset} {message}{FormatDependencyPath(dependencyPath, p)}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}/{p.Input}{input}{p.Text}:{p.Default} {message}{FormatDependencyPath(dependencyPath, p)}";
 
         private static string Format<TInput>(
             string prefix,
@@ -76,16 +76,16 @@ namespace Bullseye.Internal
             TimeSpan duration,
             IReadOnlyCollection<Target> dependencyPath,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Target}{target}{p.Default}/{p.Input}{input}{p.Default}:{p.Reset} {message} {p.Timing}({duration.Humanize()}){p.Reset}{FormatDependencyPath(dependencyPath, p)}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Target}{target}{p.Text}/{p.Input}{input}{p.Text}:{p.Default} {message} {p.Timing}({duration.Humanize()}){p.Default}{FormatDependencyPath(dependencyPath, p)}";
 
         private static string Format(
             string prefix,
             string subject,
             string message,
             Palette p) =>
-            $"{p.Prefix}{prefix}:{p.Reset} {p.Verbose}{subject}:{p.Reset} {message}";
+            $"{p.Prefix}{prefix}:{p.Default} {p.Verbose}{subject}:{p.Default} {message}";
 
         private static string FormatDependencyPath(IReadOnlyCollection<Target> dependencyPath, Palette p) =>
-            dependencyPath.Count == 0 ? "" : $" {p.Verbose}(/{string.Join("/", dependencyPath)}){p.Reset}";
+            dependencyPath.Count == 0 ? "" : $" {p.Verbose}(/{string.Join("/", dependencyPath)}){p.Default}";
     }
 }

--- a/Bullseye/Internal/Output.Results.cs
+++ b/Bullseye/Internal/Output.Results.cs
@@ -30,38 +30,38 @@ namespace Bullseye.Internal
             // whitespace (e.g. can change to '·' for debugging)
             var ws = ' ';
 
-            var rows = new List<SummaryRow> { new SummaryRow($"{p.Default}Target{p.Reset}", $"{p.Default}Outcome{p.Reset}", $"{p.Default}Duration{p.Reset}", ""), };
+            var rows = new List<SummaryRow> { new SummaryRow($"{p.Text}Target{p.Default}", $"{p.Text}Outcome{p.Default}", $"{p.Text}Duration{p.Default}", ""), };
 
             foreach (var (target, targetResult) in results.OrderBy(i => i.Value.Ordinal))
             {
                 var outcome = targetResult.Outcome switch
                 {
-                    TargetOutcome.Failed => $"{p.Failed}{FailedMessage}{p.Reset}",
-                    TargetOutcome.NoInputs => $"{p.Warning}{NoInputsMessage}{p.Reset}",
-                    TargetOutcome.Succeeded => $"{p.Succeeded}{SucceededMessage}{p.Reset}",
+                    TargetOutcome.Failed => $"{p.Failure}{FailedMessage}{p.Default}",
+                    TargetOutcome.NoInputs => $"{p.Warning}{NoInputsMessage}{p.Default}",
+                    TargetOutcome.Succeeded => $"{p.Success}{SucceededMessage}{p.Default}",
                     _ => throw new InvalidOperationException(),
                 };
 
-                var duration = $"{p.Timing}{targetResult.Duration.Humanize()}{p.Reset}";
+                var duration = $"{p.Timing}{targetResult.Duration.Humanize()}{p.Default}";
 
                 var percentage = totalDuration > TimeSpan.Zero
-                    ? $"{p.Timing}{100 * targetResult.Duration.TotalMilliseconds / totalDuration.TotalMilliseconds:N1}%{p.Reset}"
+                    ? $"{p.Timing}{100 * targetResult.Duration.TotalMilliseconds / totalDuration.TotalMilliseconds:N1}%{p.Default}"
                     : "";
 
-                rows.Add(new SummaryRow($"{p.Target}{target}{p.Reset}", outcome, duration, percentage));
+                rows.Add(new SummaryRow($"{p.Target}{target}{p.Default}", outcome, duration, percentage));
 
                 var index = 0;
 
                 foreach (var inputResult in targetResult.InputResults.Values.OrderBy(result => result.Ordinal))
                 {
-                    var input = $"{ws}{ws}{p.Input}{inputResult.Input}{p.Reset}";
+                    var input = $"{ws}{ws}{p.Input}{inputResult.Input}{p.Default}";
 
-                    var inputOutcome = inputResult.Outcome == TargetInputOutcome.Failed ? $"{p.Failed}{FailedMessage}{p.Reset}" : $"{p.Succeeded}{SucceededMessage}{p.Reset}";
+                    var inputOutcome = inputResult.Outcome == TargetInputOutcome.Failed ? $"{p.Failure}{FailedMessage}{p.Default}" : $"{p.Success}{SucceededMessage}{p.Default}";
 
-                    var inputDuration = $"{(index < targetResult.InputResults.Count - 1 ? p.TreeFork : p.TreeCorner)}{p.Timing}{inputResult.Duration.Humanize()}{p.Reset}";
+                    var inputDuration = $"{(index < targetResult.InputResults.Count - 1 ? p.TreeFork : p.TreeCorner)}{p.Timing}{inputResult.Duration.Humanize()}{p.Default}";
 
                     var inputPercentage = totalDuration > TimeSpan.Zero
-                        ? $"{(index < targetResult.InputResults.Count - 1 ? p.TreeFork : p.TreeCorner)}{p.Timing}{100 * inputResult.Duration.TotalMilliseconds / totalDuration.TotalMilliseconds:N1}%{p.Reset}"
+                        ? $"{(index < targetResult.InputResults.Count - 1 ? p.TreeFork : p.TreeCorner)}{p.Timing}{100 * inputResult.Duration.TotalMilliseconds / totalDuration.TotalMilliseconds:N1}%{p.Default}"
                         : "";
 
                     rows.Add(new SummaryRow(input, inputOutcome, inputDuration, inputPercentage));
@@ -91,22 +91,22 @@ namespace Bullseye.Internal
             var builder = new StringBuilder();
 
             // summary start separator
-            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Reset} {p.Default}{Prp("", tarW + 2 + outW + 2 + timW, p.Horizontal)}{p.Reset}");
+            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Default} {p.Text}{Prp("", tarW + 2 + outW + 2 + timW, p.Horizontal)}{p.Default}");
 
             // header
-            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Reset} {Prp(rows[0].TargetOrInput, tarW, ws)}{ws}{ws}{Prp(rows[0].Outcome, outW, ws)}{ws}{ws}{Prp(rows[0].Duration, timW, ws)}");
+            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Default} {Prp(rows[0].TargetOrInput, tarW, ws)}{ws}{ws}{Prp(rows[0].Outcome, outW, ws)}{ws}{ws}{Prp(rows[0].Duration, timW, ws)}");
 
             // header separator
-            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Reset} {p.Default}{Prp("", tarW, p.Horizontal)}{p.Reset}{ws}{ws}{p.Default}{Prp("", outW, p.Horizontal)}{p.Reset}{ws}{ws}{p.Default}{Prp("", timW, p.Horizontal)}{p.Reset}");
+            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Default} {p.Text}{Prp("", tarW, p.Horizontal)}{p.Default}{ws}{ws}{p.Text}{Prp("", outW, p.Horizontal)}{p.Default}{ws}{ws}{p.Text}{Prp("", timW, p.Horizontal)}{p.Default}");
 
             // targets
             foreach (var row in rows.Skip(1))
             {
-                _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Reset} {Prp(row.TargetOrInput, tarW, ws)}{p.Reset}{ws}{ws}{Prp(row.Outcome, outW, ws)}{p.Reset}{ws}{ws}{Prp(row.Duration, durW, ws)}{p.Reset}{ws}{ws}{Prp(row.Percentage, perW, ws)}{p.Reset}");
+                _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Default} {Prp(row.TargetOrInput, tarW, ws)}{p.Default}{ws}{ws}{Prp(row.Outcome, outW, ws)}{p.Default}{ws}{ws}{Prp(row.Duration, durW, ws)}{p.Default}{ws}{ws}{Prp(row.Percentage, perW, ws)}{p.Default}");
             }
 
             // summary end separator
-            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Reset} {p.Default}{Prp("", tarW + 2 + outW + 2 + timW, p.Horizontal)}{p.Reset}");
+            _ = builder.AppendLine($"{p.Prefix}{getPrefix()}:{p.Default} {p.Text}{Prp("", tarW + 2 + outW + 2 + timW, p.Horizontal)}{p.Default}");
 
             return builder.ToString();
 

--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -76,10 +76,10 @@ namespace Bullseye.Internal
             var version = getVersion();
 
             var builder = new StringBuilder()
-                .AppendLine(Format(this.getPrefix(), "Bullseye version", $"{this.palette.Verbose}{version}{this.palette.Reset}", this.palette))
-                .AppendLine(Format(this.getPrefix(), "Host", $"{this.palette.Verbose}{this.host} ({(this.hostForced ? "forced" : "detected")}){this.palette.Reset}", this.palette))
-                .AppendLine(Format(this.getPrefix(), "OS", $"{this.palette.Verbose}{this.osPlatform.Humanize()}{this.palette.Reset}", this.palette))
-                .AppendLine(Format(this.getPrefix(), "Args", $"{this.palette.Verbose}{string.Join(" ", this.args)}{this.palette.Reset}", this.palette));
+                .AppendLine(Format(this.getPrefix(), "Bullseye version", $"{this.palette.Verbose}{version}{this.palette.Default}", this.palette))
+                .AppendLine(Format(this.getPrefix(), "Host", $"{this.palette.Verbose}{this.host} ({(this.hostForced ? "forced" : "detected")}){this.palette.Default}", this.palette))
+                .AppendLine(Format(this.getPrefix(), "OS", $"{this.palette.Verbose}{this.osPlatform.Humanize()}{this.palette.Default}", this.palette))
+                .AppendLine(Format(this.getPrefix(), "Args", $"{this.palette.Verbose}{string.Join(" ", this.args)}{this.palette.Default}", this.palette));
 
             await this.writer.WriteAsync(builder.ToString()).Tax();
         }
@@ -96,12 +96,12 @@ namespace Bullseye.Internal
             this.writer.WriteAsync(GetListLines(targets, rootTargets, maxDepth, maxDepthToShowInputs, listInputs, "", this.palette));
 
         public Task Starting(IEnumerable<Target> targets) =>
-            this.writer.WriteLineAsync(Format(this.getPrefix(), targets, $"{this.palette.Default}{StartingMessage}{this.palette.Reset}", this.dryRun, this.parallel, this.skipDependencies, this.palette));
+            this.writer.WriteLineAsync(Format(this.getPrefix(), targets, $"{this.palette.Text}{StartingMessage}{this.palette.Default}", this.dryRun, this.parallel, this.skipDependencies, this.palette));
 
         public async Task Failed(IEnumerable<Target> targets)
         {
             var message = GetResultLines(this.results, this.totalDuration, this.getPrefix, this.palette)
-                + Format(this.getPrefix(), targets, $"{this.palette.Failed}{FailedMessage}{this.palette.Reset}", this.dryRun, this.parallel, this.skipDependencies, this.totalDuration, this.palette);
+                + Format(this.getPrefix(), targets, $"{this.palette.Failure}{FailedMessage}{this.palette.Default}", this.dryRun, this.parallel, this.skipDependencies, this.totalDuration, this.palette);
 
             await this.writer.WriteLineAsync(message).Tax();
         }
@@ -109,7 +109,7 @@ namespace Bullseye.Internal
         public async Task Succeeded(IEnumerable<Target> targets)
         {
             var message = GetResultLines(this.results, this.totalDuration, this.getPrefix, this.palette)
-                + Format(this.getPrefix(), targets, $"{this.palette.Succeeded}{SucceededMessage}{this.palette.Reset}", this.dryRun, this.parallel, this.skipDependencies, this.totalDuration, this.palette);
+                + Format(this.getPrefix(), targets, $"{this.palette.Success}{SucceededMessage}{this.palette.Default}", this.dryRun, this.parallel, this.skipDependencies, this.totalDuration, this.palette);
 
             await this.writer.WriteLineAsync(message).Tax();
         }
@@ -118,7 +118,7 @@ namespace Bullseye.Internal
         {
             if (this.Verbose)
             {
-                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Awaiting{this.palette.Reset}", dependencyPath, this.palette)).Tax();
+                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Awaiting{this.palette.Default}", dependencyPath, this.palette)).Tax();
             }
         }
 
@@ -126,7 +126,7 @@ namespace Bullseye.Internal
         {
             if (this.Verbose)
             {
-                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Walking dependencies{this.palette.Reset}", dependencyPath, this.palette)).Tax();
+                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Walking dependencies{this.palette.Default}", dependencyPath, this.palette)).Tax();
             }
         }
 
@@ -134,7 +134,7 @@ namespace Bullseye.Internal
         {
             if (this.Verbose)
             {
-                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Ignoring non-existent dependency:{this.palette.Reset} {this.palette.Target}{dependency}{this.palette.Reset}", dependencyPath, this.palette)).Tax();
+                await this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Verbose}Ignoring non-existent dependency:{this.palette.Default} {this.palette.Target}{dependency}{this.palette.Default}", dependencyPath, this.palette)).Tax();
             }
         }
 
@@ -142,7 +142,7 @@ namespace Bullseye.Internal
         {
             if (!this.parallel && this.host == Host.GitHubActions)
             {
-                await this.writer.WriteLineAsync($"::group::{this.palette.Prefix}{this.getPrefix()}:{this.palette.Reset} {this.palette.Target}{target}{this.palette.Reset}").Tax();
+                await this.writer.WriteLineAsync($"::group::{this.palette.Prefix}{this.getPrefix()}:{this.palette.Default} {this.palette.Target}{target}{this.palette.Default}").Tax();
             }
         }
 
@@ -150,7 +150,7 @@ namespace Bullseye.Internal
         {
             if (!this.parallel && this.host == Host.GitHubActions)
             {
-                await this.writer.WriteLineAsync($"::group::{this.palette.Prefix}{this.getPrefix()}:{this.palette.Reset} {this.palette.Target}{target}{this.palette.Default}/{this.palette.Input}{input}{this.palette.Reset}").Tax();
+                await this.writer.WriteLineAsync($"::group::{this.palette.Prefix}{this.getPrefix()}:{this.palette.Default} {this.palette.Target}{target}{this.palette.Text}/{this.palette.Input}{input}{this.palette.Default}").Tax();
             }
         }
 
@@ -166,11 +166,11 @@ namespace Bullseye.Internal
         {
             _ = this.InternResult(target);
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Default}{StartingMessage}{this.palette.Reset}", dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Text}{StartingMessage}{this.palette.Default}", dependencyPath, this.palette));
         }
 
         public Task Error(Target target, Exception ex) =>
-            this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Failed}{ex}{this.palette.Reset}", this.palette));
+            this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Failure}{ex}{this.palette.Default}", this.palette));
 
         public Task Failed(Target target, Exception ex, TimeSpan duration, IReadOnlyCollection<Target> dependencyPath)
         {
@@ -180,7 +180,7 @@ namespace Bullseye.Internal
 
             this.totalDuration = this.totalDuration.Add(duration);
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Failed}{FailedMessage}{this.palette.Reset} {this.palette.Failed}{ex.Message}{this.palette.Reset}", result.Duration, dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Failure}{FailedMessage}{this.palette.Default} {this.palette.Failure}{ex.Message}{this.palette.Default}", result.Duration, dependencyPath, this.palette));
         }
 
         public Task Succeeded(Target target, IReadOnlyCollection<Target> dependencyPath, TimeSpan duration)
@@ -191,7 +191,7 @@ namespace Bullseye.Internal
 
             this.totalDuration = this.totalDuration.Add(duration);
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Succeeded}{SucceededMessage}{this.palette.Reset}", result.Duration, dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Success}{SucceededMessage}{this.palette.Default}", result.Duration, dependencyPath, this.palette));
         }
 
         public Task NoInputs(Target target, IReadOnlyCollection<Target> dependencyPath)
@@ -199,7 +199,7 @@ namespace Bullseye.Internal
             var result = this.InternResult(target);
             result.Outcome = TargetOutcome.NoInputs;
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Warning}{NoInputsMessage}{this.palette.Reset}", result.Duration, dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, $"{this.palette.Warning}{NoInputsMessage}{this.palette.Default}", result.Duration, dependencyPath, this.palette));
         }
 
         public Task Starting<TInput>(Target target, TInput input, Guid inputId, IReadOnlyCollection<Target> dependencyPath)
@@ -211,7 +211,7 @@ namespace Bullseye.Internal
         }
 
         public Task Error<TInput>(Target target, TInput input, Exception ex) =>
-            this.writer.WriteLineAsync(Format(this.getPrefix(), target, input, $"{this.palette.Failed}{ex}{this.palette.Reset}", this.palette));
+            this.writer.WriteLineAsync(Format(this.getPrefix(), target, input, $"{this.palette.Failure}{ex}{this.palette.Default}", this.palette));
 
         public Task Failed<TInput>(Target target, TInput input, Guid inputId, Exception ex, TimeSpan duration, IReadOnlyCollection<Target> dependencyPath)
         {
@@ -226,7 +226,7 @@ namespace Bullseye.Internal
 
             this.totalDuration = this.totalDuration.Add(duration);
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, targetInputResult.Input, $"{this.palette.Failed}{FailedMessage}{this.palette.Reset} {this.palette.Failed}{ex.Message}{this.palette.Reset}", targetInputResult.Duration, dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, targetInputResult.Input, $"{this.palette.Failure}{FailedMessage}{this.palette.Default} {this.palette.Failure}{ex.Message}{this.palette.Default}", targetInputResult.Duration, dependencyPath, this.palette));
         }
 
         public Task Succeeded<TInput>(Target target, TInput input, Guid inputId, IReadOnlyCollection<Target> dependencyPath, TimeSpan duration)
@@ -241,49 +241,49 @@ namespace Bullseye.Internal
 
             this.totalDuration = this.totalDuration.Add(duration);
 
-            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, targetInputResult.Input, $"{this.palette.Succeeded}{SucceededMessage}{this.palette.Reset}", targetInputResult.Duration, dependencyPath, this.palette));
+            return this.writer.WriteLineAsync(Format(this.getPrefix(), target, targetInputResult.Input, $"{this.palette.Success}{SucceededMessage}{this.palette.Default}", targetInputResult.Duration, dependencyPath, this.palette));
         }
 
         // editorconfig-checker-disable
         private static string GetUsageLines(Palette p, string scriptExtension) =>
-$@"{p.Default}Usage:{p.Reset}
-  {p.Invocation}[invocation]{p.Reset} {p.Option}[options]{p.Reset} {p.Target}[<targets>...]{p.Reset}
+$@"{p.Text}Usage:{p.Default}
+  {p.Invocation}[invocation]{p.Default} {p.Option}[options]{p.Default} {p.Target}[<targets>...]{p.Default}
 
-{p.Default}Arguments:{p.Reset}
-  {p.Target}<targets>{p.Reset}    {p.Default}A list of targets to run or list. If not specified, the {p.Target}""default""{p.Default} target will be run, or all targets will be listed. Target names may be abbreviated. For example, {p.Target}""b""{p.Default} for {p.Target}""build""{p.Default}.{p.Reset}
+{p.Text}Arguments:{p.Default}
+  {p.Target}<targets>{p.Default}    {p.Text}A list of targets to run or list. If not specified, the {p.Target}""default""{p.Text} target will be run, or all targets will be listed. Target names may be abbreviated. For example, {p.Target}""b""{p.Text} for {p.Target}""build""{p.Text}.{p.Default}
 
-{p.Default}Options:{p.Reset}
-  {p.Option}-c{p.Default},{p.Reset} {p.Option}--clear{p.Reset}                {p.Default}Clear the console before execution{p.Reset}
-  {p.Option}-n{p.Default},{p.Reset} {p.Option}--dry-run{p.Reset}              {p.Default}Do a dry run without executing actions{p.Reset}
-  {p.Option}-d{p.Default},{p.Reset} {p.Option}--list-dependencies{p.Reset}    {p.Default}List all (or specified) targets and dependencies, then exit{p.Reset}
-  {p.Option}-i{p.Default},{p.Reset} {p.Option}--list-inputs{p.Reset}          {p.Default}List all (or specified) targets and inputs, then exit{p.Reset}
-  {p.Option}-l{p.Default},{p.Reset} {p.Option}--list-targets{p.Reset}         {p.Default}List all (or specified) targets, then exit{p.Reset}
-  {p.Option}-t{p.Default},{p.Reset} {p.Option}--list-tree{p.Reset}            {p.Default}List all (or specified) targets and dependency trees, then exit{p.Reset}
-  {p.Option}-N{p.Default},{p.Reset} {p.Option}--no-color{p.Reset}             {p.Default}Disable colored output{p.Reset}
-  {p.Option}-E{p.Default},{p.Reset} {p.Option}--no-extended-chars{p.Reset}    {p.Default}Disable extended characters{p.Reset}
-  {p.Option}-p{p.Default},{p.Reset} {p.Option}--parallel{p.Reset}             {p.Default}Run targets in parallel{p.Reset}
-  {p.Option}-s{p.Default},{p.Reset} {p.Option}--skip-dependencies{p.Reset}    {p.Default}Do not run targets' dependencies{p.Reset}
-  {p.Option}-v{p.Default},{p.Reset} {p.Option}--verbose{p.Reset}              {p.Default}Enable verbose output{p.Reset}
-  {p.Option}--appveyor{p.Reset}                 {p.Default}Force AppVeyor mode (normally auto-detected){p.Reset}
-  {p.Option}--console{p.Reset}                  {p.Default}Force console mode (normally auto-detected){p.Reset}
-  {p.Option}--github-actions{p.Reset}           {p.Default}Force GitHub Actions mode (normally auto-detected){p.Reset}
-  {p.Option}--gitlab-ci{p.Reset}                {p.Default}Force GitLab CI mode (normally auto-detected){p.Reset}
-  {p.Option}--teamcity{p.Reset}                 {p.Default}Force TeamCity mode (normally auto-detected){p.Reset}
-  {p.Option}--travis{p.Reset}                   {p.Default}Force Travis CI mode (normally auto-detected){p.Reset}
-  {p.Option}-?{p.Default},{p.Reset} {p.Option}-h{p.Default},{p.Reset} {p.Option}--help{p.Reset}             {p.Default}Show help and usage information, then exit (case insensitive){p.Reset}
+{p.Text}Options:{p.Default}
+  {p.Option}-c{p.Text},{p.Default} {p.Option}--clear{p.Default}                {p.Text}Clear the console before execution{p.Default}
+  {p.Option}-n{p.Text},{p.Default} {p.Option}--dry-run{p.Default}              {p.Text}Do a dry run without executing actions{p.Default}
+  {p.Option}-d{p.Text},{p.Default} {p.Option}--list-dependencies{p.Default}    {p.Text}List all (or specified) targets and dependencies, then exit{p.Default}
+  {p.Option}-i{p.Text},{p.Default} {p.Option}--list-inputs{p.Default}          {p.Text}List all (or specified) targets and inputs, then exit{p.Default}
+  {p.Option}-l{p.Text},{p.Default} {p.Option}--list-targets{p.Default}         {p.Text}List all (or specified) targets, then exit{p.Default}
+  {p.Option}-t{p.Text},{p.Default} {p.Option}--list-tree{p.Default}            {p.Text}List all (or specified) targets and dependency trees, then exit{p.Default}
+  {p.Option}-N{p.Text},{p.Default} {p.Option}--no-color{p.Default}             {p.Text}Disable colored output{p.Default}
+  {p.Option}-E{p.Text},{p.Default} {p.Option}--no-extended-chars{p.Default}    {p.Text}Disable extended characters{p.Default}
+  {p.Option}-p{p.Text},{p.Default} {p.Option}--parallel{p.Default}             {p.Text}Run targets in parallel{p.Default}
+  {p.Option}-s{p.Text},{p.Default} {p.Option}--skip-dependencies{p.Default}    {p.Text}Do not run targets' dependencies{p.Default}
+  {p.Option}-v{p.Text},{p.Default} {p.Option}--verbose{p.Default}              {p.Text}Enable verbose output{p.Default}
+  {p.Option}--appveyor{p.Default}                 {p.Text}Force AppVeyor mode (normally auto-detected){p.Default}
+  {p.Option}--console{p.Default}                  {p.Text}Force console mode (normally auto-detected){p.Default}
+  {p.Option}--github-actions{p.Default}           {p.Text}Force GitHub Actions mode (normally auto-detected){p.Default}
+  {p.Option}--gitlab-ci{p.Default}                {p.Text}Force GitLab CI mode (normally auto-detected){p.Default}
+  {p.Option}--teamcity{p.Default}                 {p.Text}Force TeamCity mode (normally auto-detected){p.Default}
+  {p.Option}--travis{p.Default}                   {p.Text}Force Travis CI mode (normally auto-detected){p.Default}
+  {p.Option}-?{p.Text},{p.Default} {p.Option}-h{p.Text},{p.Default} {p.Option}--help{p.Default}             {p.Text}Show help and usage information, then exit (case insensitive){p.Default}
 
-{p.Default}Remarks:{p.Reset}
-  {p.Default}The {p.Option}--list-xxx{p.Default} options may be combined.{p.Reset}
-  {p.Default}The {p.Invocation}invocation{p.Default} is typically a call to dotnet run, or the path to a script which wraps a call to dotnet run.{p.Reset}
+{p.Text}Remarks:{p.Default}
+  {p.Text}The {p.Option}--list-xxx{p.Text} options may be combined.{p.Default}
+  {p.Text}The {p.Invocation}invocation{p.Text} is typically a call to dotnet run, or the path to a script which wraps a call to dotnet run.{p.Default}
 
-{p.Default}Examples:{p.Reset}
-  {p.Invocation}./build.{scriptExtension}{p.Reset}
-  {p.Invocation}./build.{scriptExtension}{p.Reset} {p.Option}-d{p.Reset}
-  {p.Invocation}./build.{scriptExtension}{p.Reset} {p.Option}-t{p.Reset} {p.Option}-i{p.Reset} {p.Target}default{p.Reset}
-  {p.Invocation}./build.{scriptExtension}{p.Reset} {p.Target}test{p.Reset} {p.Target}pack{p.Reset}
-  {p.Invocation}dotnet run --project targets --{p.Reset} {p.Option}-n{p.Reset} {p.Target}build{p.Reset}
+{p.Text}Examples:{p.Default}
+  {p.Invocation}./build.{scriptExtension}{p.Default}
+  {p.Invocation}./build.{scriptExtension}{p.Default} {p.Option}-d{p.Default}
+  {p.Invocation}./build.{scriptExtension}{p.Default} {p.Option}-t{p.Default} {p.Option}-i{p.Default} {p.Target}default{p.Default}
+  {p.Invocation}./build.{scriptExtension}{p.Default} {p.Target}test{p.Default} {p.Target}pack{p.Default}
+  {p.Invocation}dotnet run --project targets --{p.Default} {p.Option}-n{p.Default} {p.Target}build{p.Default}
 
-{p.Default}Targets:{p.Reset}
+{p.Text}Targets:{p.Default}
 "; // editorconfig-checker-enable
 
         private static string GetListLines(TargetCollection targets, IEnumerable<string> rootTargets, int maxDepth, int maxDepthToShowInputs, bool listInputs, string startingPrefix, Palette p)
@@ -316,7 +316,7 @@ $@"{p.Default}Usage:{p.Reset}
                     {
                         var prefix = isRoot
                             ? startingPrefix
-                            : $"{previousPrefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeDown, StringComparison.Ordinal)}{(item.index == names.Count - 1 ? p.TreeCorner : p.TreeFork)}";
+                            : $"{previousPrefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeLine, StringComparison.Ordinal)}{(item.index == names.Count - 1 ? p.TreeCorner : p.TreeFork)}";
 
                         var isMissing = !targets.Contains(item.name);
 
@@ -324,17 +324,17 @@ $@"{p.Default}Usage:{p.Reset}
 
                         if (isMissing)
                         {
-                            lines.Add((line + $"{p.Reset} {p.Failed}(missing){p.Reset}", ""));
+                            lines.Add((line + $"{p.Default} {p.Failure}(missing){p.Default}", ""));
                             continue;
                         }
 
                         if (circularDependency)
                         {
-                            lines.Add((line + $"{p.Reset} {p.Failed}(circular dependency){p.Reset}", targets[item.name].Description));
+                            lines.Add((line + $"{p.Default} {p.Failure}(circular dependency){p.Default}", targets[item.name].Description));
                             continue;
                         }
 
-                        lines.Add((line + p.Reset, targets[item.name].Description));
+                        lines.Add((line + p.Default, targets[item.name].Description));
 
                         var target = targets[item.name];
 
@@ -342,9 +342,9 @@ $@"{p.Default}Usage:{p.Reset}
                         {
                             foreach (var inputItem in hasInputs.Inputs.Select((input, index) => new { input, index, }))
                             {
-                                var inputPrefix = $"{prefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeDown, StringComparison.Ordinal)}{(target.Dependencies.Count > 0 && depth + 1 <= maxDepth ? p.TreeDown : "  ")}";
+                                var inputPrefix = $"{prefix.Replace(p.TreeCorner, "  ", StringComparison.Ordinal).Replace(p.TreeFork, p.TreeLine, StringComparison.Ordinal)}{(target.Dependencies.Count > 0 && depth + 1 <= maxDepth ? p.TreeLine : "  ")}";
 
-                                lines.Add(($"{inputPrefix}{p.Input}{inputItem.input}{p.Reset}", ""));
+                                lines.Add(($"{inputPrefix}{p.Input}{inputItem.input}{p.Default}", ""));
                             }
                         }
 

--- a/Bullseye/Internal/TargetCollectionExtensions.cs
+++ b/Bullseye/Internal/TargetCollectionExtensions.cs
@@ -131,7 +131,7 @@ namespace Bullseye.Internal
                 noColor = true;
             }
 
-            var host = options.Host.DetectIfAutomatic();
+            var host = options.Host.DetectIfNull();
 
             var osPlatform =
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -148,7 +148,7 @@ namespace Bullseye.Internal
                 args,
                 options.DryRun,
                 host,
-                options.Host != Host.Automatic,
+                options.Host != null,
                 noColor,
                 options.NoExtendedChars,
                 osPlatform,

--- a/Bullseye/Options.Properties.cs
+++ b/Bullseye/Options.Properties.cs
@@ -63,6 +63,6 @@ namespace Bullseye
         /// <summary>
         /// Gets or sets a value indicating which mode to use for a specific host environment.
         /// </summary>
-        public Host Host { get; set; }
+        public Host? Host { get; set; }
     }
 }

--- a/Bullseye/Palette.cs
+++ b/Bullseye/Palette.cs
@@ -1,12 +1,22 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Bullseye.Internal
+namespace Bullseye
 {
+    /// <summary>
+    /// A palette of strings representing color and other characters.
+    /// </summary>
     public class Palette
     {
         private static readonly int[] numbers = { 0, 30, 31, 32, 33, 34, 35, 36, 37, 90, 91, 92, 93, 94, 95, 96, 97, };
 
+        /// <summary>
+        /// Constructs an instance of <see cref="Palette"/>.
+        /// </summary>
+        /// <param name="noColor">Whether to use color or not.</param>
+        /// <param name="noExtendedChars">Whether to use extended characters or not.</param>
+        /// <param name="host">The host environment.</param>
+        /// <param name="osPlatform">The OS platform.</param>
         public Palette(bool noColor, bool noExtendedChars, Host host, OSPlatform osPlatform)
         {
             var reset = noColor ? "" : "\x1b[0m";
@@ -48,13 +58,13 @@ namespace Bullseye.Internal
             ////brightWhite = Console.BackgroundColor == ConsoleColor.White ? white : brightWhite;
 
             this.Invocation = brightYellow;
-            this.Default = white;
-            this.Failed = brightRed;
+            this.Text = white;
+            this.Failure = brightRed;
             this.Input = brightCyan;
             this.Option = brightMagenta;
             this.Prefix = brightBlack;
-            this.Reset = reset;
-            this.Succeeded = green;
+            this.Default = reset;
+            this.Success = green;
             this.Target = cyan;
             this.Timing = magenta;
             this.Verbose = brightBlack;
@@ -62,45 +72,45 @@ namespace Bullseye.Internal
 
             this.TreeCorner = $"{green}└─{reset}";
             this.TreeFork = $"{green}├─{reset}";
-            this.TreeDown = $"{green}│{reset} ";
+            this.TreeLine = $"{green}│{reset} ";
             this.Horizontal = '─';
 
 #pragma warning disable IDE0010 // Add missing cases to switch statement
             switch (host)
             {
                 case Host.AppVeyor when osPlatform == OSPlatform.Windows:
-                    this.Default = brightBlack;
+                    this.Text = brightBlack;
                     this.Target = blue;
                     this.TreeCorner = "  ";
                     this.TreeFork = "  ";
-                    this.TreeDown = "  ";
+                    this.TreeLine = "  ";
                     this.Horizontal = '-';
                     break;
                 case Host.AppVeyor when osPlatform == OSPlatform.Linux:
-                    this.Default = brightBlack;
+                    this.Text = brightBlack;
                     this.Target = blue;
                     this.Timing = brightMagenta;
                     break;
                 case Host.GitHubActions:
                     this.Invocation = yellow;
-                    this.Failed = red;
+                    this.Failure = red;
                     this.Target = blue;
                     break;
                 case Host.GitLabCI:
                     this.Target = blue;
                     break;
                 case Host.TeamCity:
-                    this.Default = brightBlack;
+                    this.Text = brightBlack;
                     this.Target = brightBlue;
                     this.TreeCorner = "  ";
                     this.TreeFork = "  ";
-                    this.TreeDown = "  ";
+                    this.TreeLine = "  ";
                     this.Horizontal = '-';
                     break;
                 case Host.Travis:
                     this.Invocation = yellow;
-                    this.Default = brightBlack;
-                    this.Failed = red;
+                    this.Text = brightBlack;
+                    this.Failure = red;
                     this.Input = cyan;
                     this.Option = magenta;
                     this.Target = blue;
@@ -116,43 +126,96 @@ namespace Bullseye.Internal
             {
                 this.TreeCorner = "  ";
                 this.TreeFork = "  ";
-                this.TreeDown = "  ";
+                this.TreeLine = "  ";
                 this.Horizontal = '-';
             }
         }
 
+        /// <summary>
+        /// The color to use for a command invocation.
+        /// </summary>
         public string Invocation { get; }
 
-        public string Reset { get; }
-
-        public string Failed { get; }
-
-        public string Input { get; }
-
-        public string Option { get; }
-
-        public string Prefix { get; }
-
-        public string Succeeded { get; }
-
-        public string Target { get; }
-
+        /// <summary>
+        /// The default color.
+        /// </summary>
         public string Default { get; }
 
+        /// <summary>
+        /// The color to use for a failure.
+        /// </summary>
+        public string Failure { get; }
+
+        /// <summary>
+        /// The color to use for an input.
+        /// </summary>
+        public string Input { get; }
+
+        /// <summary>
+        /// The color to use for a command option.
+        /// </summary>
+        public string Option { get; }
+
+        /// <summary>
+        /// The color to use for a program prefix.
+        /// </summary>
+        public string Prefix { get; }
+
+        /// <summary>
+        /// The color to use for success.
+        /// </summary>
+        public string Success { get; }
+
+        /// <summary>
+        /// The color to use for a target.
+        /// </summary>
+        public string Target { get; }
+
+        /// <summary>
+        /// The color to use for arbitrary text.
+        /// </summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// The color to use for a timing.
+        /// </summary>
         public string Timing { get; }
 
+        /// <summary>
+        /// The color to use for a verbose message.
+        /// </summary>
         public string Verbose { get; }
 
+        /// <summary>
+        /// The color to use for a warning.
+        /// </summary>
         public string Warning { get; }
 
+        /// <summary>
+        /// The string to use for a tree corner.
+        /// </summary>
         public string TreeCorner { get; }
 
+        /// <summary>
+        /// The string to use for a tree fork.
+        /// </summary>
         public string TreeFork { get; }
 
-        public string TreeDown { get; }
+        /// <summary>
+        /// The string to use for a tree line.
+        /// </summary>
+        public string TreeLine { get; }
 
+        /// <summary>
+        /// The string to use for a horizontal line.
+        /// </summary>
         public char Horizontal { get; }
 
+        /// <summary>
+        /// Strip colors from a specified <see cref="string"/>.
+        /// </summary>
+        /// <param name="text">The <see cref="string"/> from which to strip colors.</param>
+        /// <returns>A <see cref="string"/> representing the original string with colors stripped.</returns>
         public static string StripColors(string text)
         {
             if (string.IsNullOrWhiteSpace(text))

--- a/Bullseye/PublicAPI.Shipped.txt
+++ b/Bullseye/PublicAPI.Shipped.txt
@@ -1,14 +1,14 @@
 #nullable enable
 Bullseye.CommandLine
 Bullseye.Host
-Bullseye.Host.AppVeyor = 1 -> Bullseye.Host
-Bullseye.Host.Automatic = 0 -> Bullseye.Host
-Bullseye.Host.Console = 2 -> Bullseye.Host
-Bullseye.Host.GitHubActions = 3 -> Bullseye.Host
-Bullseye.Host.GitLabCI = 4 -> Bullseye.Host
-Bullseye.Host.TeamCity = 5 -> Bullseye.Host
-Bullseye.Host.Travis = 6 -> Bullseye.Host
-Bullseye.Host.VisualStudioCode = 7 -> Bullseye.Host
+Bullseye.Host.AppVeyor = 0 -> Bullseye.Host
+Bullseye.Host.Console = 1 -> Bullseye.Host
+Bullseye.Host.GitHubActions = 2 -> Bullseye.Host
+Bullseye.Host.GitLabCI = 3 -> Bullseye.Host
+Bullseye.Host.TeamCity = 4 -> Bullseye.Host
+Bullseye.Host.Travis = 5 -> Bullseye.Host
+Bullseye.Host.VisualStudioCode = 6 -> Bullseye.Host
+Bullseye.HostExtensions
 Bullseye.InvalidUsageException
 Bullseye.InvalidUsageException.InvalidUsageException() -> void
 Bullseye.InvalidUsageException.InvalidUsageException(string! message) -> void
@@ -16,7 +16,7 @@ Bullseye.InvalidUsageException.InvalidUsageException(string! message, System.Exc
 Bullseye.IOptions
 Bullseye.IOptions.Clear.get -> bool
 Bullseye.IOptions.DryRun.get -> bool
-Bullseye.IOptions.Host.get -> Bullseye.Host
+Bullseye.IOptions.Host.get -> Bullseye.Host?
 Bullseye.IOptions.ListDependencies.get -> bool
 Bullseye.IOptions.ListInputs.get -> bool
 Bullseye.IOptions.ListTargets.get -> bool
@@ -31,7 +31,7 @@ Bullseye.Options.Clear.get -> bool
 Bullseye.Options.Clear.set -> void
 Bullseye.Options.DryRun.get -> bool
 Bullseye.Options.DryRun.set -> void
-Bullseye.Options.Host.get -> Bullseye.Host
+Bullseye.Options.Host.get -> Bullseye.Host?
 Bullseye.Options.Host.set -> void
 Bullseye.Options.ListDependencies.get -> bool
 Bullseye.Options.ListDependencies.set -> void
@@ -53,6 +53,24 @@ Bullseye.Options.SkipDependencies.get -> bool
 Bullseye.Options.SkipDependencies.set -> void
 Bullseye.Options.Verbose.get -> bool
 Bullseye.Options.Verbose.set -> void
+Bullseye.Palette
+Bullseye.Palette.Default.get -> string!
+Bullseye.Palette.Failure.get -> string!
+Bullseye.Palette.Horizontal.get -> char
+Bullseye.Palette.Input.get -> string!
+Bullseye.Palette.Invocation.get -> string!
+Bullseye.Palette.Option.get -> string!
+Bullseye.Palette.Palette(bool noColor, bool noExtendedChars, Bullseye.Host host, System.Runtime.InteropServices.OSPlatform osPlatform) -> void
+Bullseye.Palette.Prefix.get -> string!
+Bullseye.Palette.Success.get -> string!
+Bullseye.Palette.Target.get -> string!
+Bullseye.Palette.Text.get -> string!
+Bullseye.Palette.Timing.get -> string!
+Bullseye.Palette.TreeCorner.get -> string!
+Bullseye.Palette.TreeFork.get -> string!
+Bullseye.Palette.TreeLine.get -> string!
+Bullseye.Palette.Verbose.get -> string!
+Bullseye.Palette.Warning.get -> string!
 Bullseye.TargetFailedException
 Bullseye.TargetFailedException.TargetFailedException() -> void
 Bullseye.TargetFailedException.TargetFailedException(string! message) -> void
@@ -82,7 +100,9 @@ Bullseye.Targets.RunWithoutExitingAsync(System.Collections.Generic.IEnumerable<s
 Bullseye.Targets.RunWithoutExitingAsync(System.Collections.Generic.IEnumerable<string!>! targets, Bullseye.IOptions! options, System.Collections.Generic.IEnumerable<string!>? unknownOptions = null, bool showHelp = false, System.Func<System.Exception!, bool>? messageOnly = null, System.Func<string!>? getMessagePrefix = null, System.IO.TextWriter? outputWriter = null, System.IO.TextWriter? diagnosticsWriter = null) -> System.Threading.Tasks.Task!
 Bullseye.Targets.Targets() -> void
 static Bullseye.CommandLine.Parse(System.Collections.Generic.IEnumerable<string!>! args) -> (System.Collections.Generic.IReadOnlyList<string!>! Targets, Bullseye.Options! Options, System.Collections.Generic.IReadOnlyList<string!>! UnknownOptions, bool showHelp)
+static Bullseye.HostExtensions.DetectIfNull(this Bullseye.Host? host) -> Bullseye.Host
 static Bullseye.Options.Definitions.get -> System.Collections.Generic.IReadOnlyList<(System.Collections.Generic.IReadOnlyList<string!>! Aliases, string! Description)>!
+static Bullseye.Palette.StripColors(string! text) -> string!
 static Bullseye.Targets.DependsOn(params string![]! dependencies) -> string![]!
 static Bullseye.Targets.ForEach<TInput>(params TInput[]! inputs) -> TInput[]!
 static Bullseye.Targets.RunTargetsAndExitAsync(System.Collections.Generic.IEnumerable<string!>! args, System.Func<System.Exception!, bool>? messageOnly = null, System.Func<string!>? getMessagePrefix = null, System.IO.TextWriter? outputWriter = null, System.IO.TextWriter? diagnosticsWriter = null) -> System.Threading.Tasks.Task!

--- a/BullseyeTests/OutputTests.cs
+++ b/BullseyeTests/OutputTests.cs
@@ -71,7 +71,7 @@ namespace BullseyeTests
         }
 
         public static IEnumerable<object[]> Hosts() =>
-            ((Host[])Enum.GetValues(typeof(Host))).Where(host => host != Host.Automatic).Select(host => new object[] { host, });
+            ((Host[])Enum.GetValues(typeof(Host))).Select(host => new object[] { host, });
 
         private static async Task Write(
             TextWriter writer, bool noColor, bool noExtendedChars, Host host, bool hostForced, OSPlatform osPlatform, bool skipDependencies, bool dryRun, bool parallel, bool verbose, IReadOnlyCollection<string> args, int ordinal)

--- a/BullseyeTests/output.default.host.net6.0.txt
+++ b/BullseyeTests/output.default.host.net6.0.txt
@@ -1,7 +1,7 @@
 ﻿
 noColor: True
 noExtendedChars: False
-host: Automatic
+host: AppVeyor
 hostForced: True
 osPlatform: Unknown
 skipDependencies: True
@@ -11,7 +11,7 @@ verbose: True
 args: arg1 arg2
 
 prefix1: Bullseye version: version
-prefix1: Host: Automatic (forced)
+prefix1: Host: AppVeyor (forced)
 prefix1: OS: Unknown
 prefix1: Args: arg1 arg2
 prefix1: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -83,7 +83,7 @@ prefix1: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: True
-host: Automatic
+host: AppVeyor
 hostForced: False
 osPlatform: Unknown
 skipDependencies: False
@@ -93,7 +93,7 @@ verbose: True
 args: arg1 arg2
 
 prefix2: Bullseye version: version
-prefix2: Host: Automatic (detected)
+prefix2: Host: AppVeyor (detected)
 prefix2: OS: Unknown
 prefix2: Args: arg1 arg2
 prefix2: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)

--- a/BullseyeTests/output.default.host.netcoreapp3.1.txt
+++ b/BullseyeTests/output.default.host.netcoreapp3.1.txt
@@ -1,7 +1,7 @@
 ﻿
 noColor: True
 noExtendedChars: False
-host: Automatic
+host: AppVeyor
 hostForced: True
 osPlatform: Unknown
 skipDependencies: True
@@ -11,7 +11,7 @@ verbose: True
 args: arg1 arg2
 
 prefix1: Bullseye version: version
-prefix1: Host: Automatic (forced)
+prefix1: Host: AppVeyor (forced)
 prefix1: OS: Unknown
 prefix1: Args: arg1 arg2
 prefix1: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)
@@ -83,7 +83,7 @@ prefix1: FAILED! (target1 target2 target3) (dry run) (parallel) (skip dependenci
 
 noColor: True
 noExtendedChars: True
-host: Automatic
+host: AppVeyor
 hostForced: False
 osPlatform: Unknown
 skipDependencies: False
@@ -93,7 +93,7 @@ verbose: True
 args: arg1 arg2
 
 prefix2: Bullseye version: version
-prefix2: Host: Automatic (detected)
+prefix2: Host: AppVeyor (detected)
 prefix2: OS: Unknown
 prefix2: Args: arg1 arg2
 prefix2: verboseTarget3: Awaiting (/verboseTarget1/verboseTarget2/verboseTarget3)


### PR DESCRIPTION
## Use case(s)

Providing output from consuming code which matches the coloring of, and symbols used by, Bullseye output.

## Description

The `Palette` and `HostExtensions` types are now logically public. This means that they have moved from the `Bullseye.Internal` namespace to the `Bullseye` namespace. The now follow [SemVer](https://semver.org/), along with the rest of the public API.

## Alternatives

Use the types as they are, in the `Bullseye.Internal` namespace. This means they are liable to change or be removed, in any version, without notice.

## Additional context

@aaubry is already using these types in the `Bullseye.Internal` namespace. Some of that usage can be seen in [this PR](https://github.com/aaubry/YamlDotNet/pull/711/files).
