### PR TITLE
Target name abbreviation

### DIFF
--- a/Bullseye/Internal/Output.cs
+++ b/Bullseye/Internal/Output.cs
@@ -250,7 +250,7 @@ $@"{p.Default}Usage:{p.Reset}
   {p.Invocation}[invocation]{p.Reset} {p.Option}[options]{p.Reset} {p.Target}[<targets>...]{p.Reset}
 
 {p.Default}Arguments:{p.Reset}
-  {p.Target}<targets>{p.Reset}    {p.Default}A list of targets to run or list. If not specified, the {p.Target}""default""{p.Default} target will be run, or all targets will be listed.{p.Reset}
+  {p.Target}<targets>{p.Reset}    {p.Default}A list of targets to run or list. If not specified, the {p.Target}""default""{p.Default} target will be run, or all targets will be listed. Target names may be abbreviated. For example, {p.Target}""b""{p.Default} for {p.Target}""build""{p.Default}.{p.Reset}
 
 {p.Default}Options:{p.Reset}
   {p.Option}-c{p.Default},{p.Reset} {p.Option}--clear{p.Reset}                {p.Default}Clear the console before execution{p.Reset}

--- a/BullseyeTests/RunningTargets.cs
+++ b/BullseyeTests/RunningTargets.cs
@@ -52,6 +52,44 @@ namespace BullseyeTests
         }
 
         [Fact]
+        public static async Task TargetNameAbbreviation()
+        {
+            // arrange
+            var (foo, bar) = (false, false);
+
+            var targets = new TargetCollection
+            {
+                CreateTarget(nameof(foo), () => foo = true),
+                CreateTarget(nameof(bar), () => bar = true),
+            };
+
+            // act
+            await targets.RunAsync(new List<string> { nameof(foo)[..1], }, _ => false, () => "", Console.Out, Console.Error, false);
+
+            // assert
+            Assert.True(foo);
+            Assert.False(bar);
+        }
+
+        [Fact]
+        public static async Task AmbiguousTargetNameAbbreviation()
+        {
+            // arrange
+            var targets = new TargetCollection
+            {
+                CreateTarget("foo1", () => { }),
+                CreateTarget("foo2", () => { }),
+            };
+
+            // act
+            var exception = await Record.ExceptionAsync(() => targets.RunAsync(new List<string> { "f", }, _ => false, () => "", Console.Out, Console.Error, false));
+
+            // assert
+            Assert.NotNull(exception);
+            Assert.Contains("ambiguous target", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public static async Task SingleNonExistent()
         {
             // arrange


### PR DESCRIPTION
## Use case(s)

Avoiding having to provide the full names of specific targets.

## Description

When running or listing specific targets, the names of those targets may be abbreviated. E.g.

```text
$ ./build -l
build
test
pack
$ ./build t p     # runs the test and pack targets
```

If the abbreviation is ambiguous, an error is shown. E.g.

```text
$ ./build -l
build-lib
build-app
test-lib
test-app
$ ./build b t
Ambiguous targets: b (build-lib build-app) t (test-lib test-app)
$ echo $?         # gets last exit code
2
```

## Alternatives

Keep typing the full names of the targets.

## Additional context

N/A
