### PR TITLE
ShowHelp is incorrectly cased on CommandLine.Parse return type

### DIFF
--- a/Bullseye/CommandLine.cs
+++ b/Bullseye/CommandLine.cs
@@ -14,7 +14,7 @@ namespace Bullseye
         /// </summary>
         /// <param name="args">A list of argument strings.</param>
         /// <returns>An instance of <see cref="Options"/> and a list of target names.</returns>
-        public static (IReadOnlyList<string> Targets, Options Options, IReadOnlyList<string> UnknownOptions, bool showHelp) Parse(IEnumerable<string> args) =>
+        public static (IReadOnlyList<string> Targets, Options Options, IReadOnlyList<string> UnknownOptions, bool ShowHelp) Parse(IEnumerable<string> args) =>
             ArgsParser.Parse(args.ToList());
     }
 }

--- a/BullseyeTests/CommandLineTests.cs
+++ b/BullseyeTests/CommandLineTests.cs
@@ -29,7 +29,7 @@ namespace BullseyeTests
             Assert.False(result.Options.SkipDependencies);
             Assert.False(result.Options.Verbose);
 
-            Assert.False(result.showHelp);
+            Assert.False(result.ShowHelp);
             Assert.Empty(result.Targets);
             Assert.Empty(result.UnknownOptions);
         }
@@ -76,7 +76,7 @@ namespace BullseyeTests
             Assert.True(result.Options.SkipDependencies);
             Assert.True(result.Options.Verbose);
 
-            Assert.True(result.showHelp);
+            Assert.True(result.ShowHelp);
             Assert.Equal(new[] { "target0", "target1", }, result.Targets);
             Assert.Equal(new[] { "-0", "-1", }, result.UnknownOptions);
         }
@@ -123,7 +123,7 @@ namespace BullseyeTests
             Assert.True(result.Options.SkipDependencies);
             Assert.True(result.Options.Verbose);
 
-            Assert.True(result.showHelp);
+            Assert.True(result.ShowHelp);
             Assert.Equal(new[] { "target0", "target1", }, result.Targets);
             Assert.Equal(new[] { "--unknown0", "--unknown1", }, result.UnknownOptions);
         }


### PR DESCRIPTION
## Expected

`ShowHelp`

## Actual

`showHelp`